### PR TITLE
refine(mobile-menu): variant A no-navbar pill trigger

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ bottom of each `.astro` file. The design system lives in `src/styles/`.
   - JS-internal pixels in `IntersectionObserver` rootMargin (DOM API requirement).
   - Sub-pixel decoration values inside SVG data URIs.
 - **Fluid type** via `clamp(min-rem, vw-based-mid, max-rem)`. Used for
-  `.t-mega`, `.t-display`, `.t-heading`, and the Now featured `<h3>`.
+  `.t-mega`, `.t-heading`, and the Now featured `<h3>`.
 - **Intrinsic sizing.** Do **not** add `min-height: …rem` to cards. CSS Grid's
   default `align-items: stretch` keeps cards in the same row equal-height.
   Full-width cards size to content.

--- a/src/components/nav/MobileMenu.astro
+++ b/src/components/nav/MobileMenu.astro
@@ -1,5 +1,5 @@
 ---
-type NavItem = { label: string; href: string };
+type NavItem = { label: string; short?: string; href: string };
 
 type Props = {
     items: readonly NavItem[];
@@ -18,30 +18,46 @@ const { items, resumeHref = "/resume.pdf" } = Astro.props;
         aria-controls="mobile-menu-panel"
         data-mobile-menu-trigger
     >
-        <span aria-hidden="true"></span>
-        <span aria-hidden="true"></span>
-        <span aria-hidden="true"></span>
+        <span class="mobile-menu__label" data-mobile-menu-label>menu</span>
+        <span class="mobile-menu__icon" aria-hidden="true">
+            <span></span>
+            <span></span>
+            <span></span>
+        </span>
     </button>
-    <ul
+    <div
         id="mobile-menu-panel"
         class="mobile-menu__panel"
         data-mobile-menu-panel
     >
-        {
-            items.map((item) => (
-                <li>
-                    <a href={item.href} data-mobile-menu-link>
-                        {item.label}
-                    </a>
-                </li>
-            ))
-        }
-        <li>
-            <a class="resume-cta" href={resumeHref} data-mobile-menu-link>
-                Resume.pdf
-            </a>
-        </li>
-    </ul>
+        <ul class="mobile-menu__list">
+            {
+                items.map((item) => (
+                    <li>
+                        <a
+                            href={item.href}
+                            data-mobile-menu-link
+                            data-section={item.href.replace(/^#/, "")}
+                        >
+                            <span class="mobile-menu__dot" aria-hidden="true" />
+                            <span class="mobile-menu__text">
+                                {item.short ?? item.label}
+                            </span>
+                        </a>
+                    </li>
+                ))
+            }
+        </ul>
+        <div class="mobile-menu__divider" aria-hidden="true"></div>
+        <a
+            class="mobile-menu__resume"
+            href={resumeHref}
+            data-mobile-menu-link
+        >
+            <span>resume.pdf</span>
+            <span aria-hidden="true">↓</span>
+        </a>
+    </div>
 </div>
 
 <script>
@@ -50,8 +66,14 @@ const { items, resumeHref = "/resume.pdf" } = Astro.props;
         const trigger = menu.querySelector<HTMLButtonElement>(
             "[data-mobile-menu-trigger]"
         );
+        const label = menu.querySelector<HTMLElement>(
+            "[data-mobile-menu-label]"
+        );
         const links = Array.from(
             menu.querySelectorAll<HTMLAnchorElement>("[data-mobile-menu-link]")
+        );
+        const sectionLinks = links.filter((l) =>
+            l.getAttribute("href")?.startsWith("#")
         );
 
         const setOpen = (open: boolean) => {
@@ -61,6 +83,7 @@ const { items, resumeHref = "/resume.pdf" } = Astro.props;
                 "aria-label",
                 open ? "Close navigation menu" : "Open navigation menu"
             );
+            if (label) label.textContent = open ? "close" : "menu";
         };
 
         trigger?.addEventListener("click", (event) => {
@@ -88,5 +111,66 @@ const { items, resumeHref = "/resume.pdf" } = Astro.props;
                 trigger?.focus();
             }
         });
+
+        // Mirror NavCapsule's active-section tracking: highlight the menu
+        // entry whose section is the bottommost one inside the top 30% of
+        // the viewport. End-of-content forces the last item.
+        const linkBySection = new Map<HTMLElement, HTMLAnchorElement>();
+        for (const link of sectionLinks) {
+            const id = link.dataset.section;
+            if (!id) continue;
+            const section = document.getElementById(id);
+            if (section) linkBySection.set(section, link);
+        }
+
+        const setActive = (next: HTMLAnchorElement | null) => {
+            for (const l of sectionLinks) l.classList.remove("active");
+            if (next) next.classList.add("active");
+        };
+
+        const visible = new Set<Element>();
+        let endReached = false;
+
+        const orderedLinks = Array.from(linkBySection.values());
+        const update = () => {
+            if (endReached) {
+                setActive(orderedLinks[orderedLinks.length - 1] ?? null);
+                return;
+            }
+            let chosen: HTMLAnchorElement | null = null;
+            let maxTop = Number.NEGATIVE_INFINITY;
+            for (const section of visible) {
+                const top = section.getBoundingClientRect().top;
+                if (top > maxTop) {
+                    maxTop = top;
+                    chosen = linkBySection.get(section as HTMLElement) ?? null;
+                }
+            }
+            setActive(chosen);
+        };
+
+        const sectionObs = new IntersectionObserver(
+            (entries) => {
+                for (const entry of entries) {
+                    if (entry.isIntersecting) visible.add(entry.target);
+                    else visible.delete(entry.target);
+                }
+                update();
+            },
+            { rootMargin: "0px 0px -70% 0px", threshold: 0 }
+        );
+        for (const section of linkBySection.keys()) sectionObs.observe(section);
+
+        const footer = document.querySelector<HTMLElement>("footer");
+        if (footer) {
+            const endObs = new IntersectionObserver(
+                ([entry]) => {
+                    endReached = entry.isIntersecting;
+                    update();
+                },
+                { threshold: 0 }
+            );
+            endObs.observe(footer);
+        }
     }
 </script>

--- a/src/components/nav/MobileMenu.astro
+++ b/src/components/nav/MobileMenu.astro
@@ -25,9 +25,10 @@ const { items, resumeHref = "/resume.pdf" } = Astro.props;
             <span></span>
         </span>
     </button>
-    <div
+    <nav
         id="mobile-menu-panel"
         class="mobile-menu__panel"
+        aria-label="Mobile menu"
         data-mobile-menu-panel
     >
         <ul class="mobile-menu__list">
@@ -57,7 +58,7 @@ const { items, resumeHref = "/resume.pdf" } = Astro.props;
             <span>resume.pdf</span>
             <span aria-hidden="true">↓</span>
         </a>
-    </div>
+    </nav>
 </div>
 
 <script>

--- a/src/components/nav/NavCapsule.astro
+++ b/src/components/nav/NavCapsule.astro
@@ -1,5 +1,5 @@
 ---
-type NavItem = { label: string; href: string };
+type NavItem = { label: string; short?: string; href: string };
 
 type Props = {
     items: readonly NavItem[];

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -10,11 +10,11 @@ export const SITE = {
         siglum: "chomat.tech · v2 · MMXXVI",
     },
     nav: [
-        { label: "Now", href: "#now" },
-        { label: "Experience", href: "#experience" },
-        { label: "Work", href: "#work" },
-        { label: "Tech", href: "#tech" },
-        { label: "Contact", href: "#contact" },
+        { label: "Now", short: "now", href: "#now" },
+        { label: "Experience", short: "exp", href: "#experience" },
+        { label: "Work", short: "work", href: "#work" },
+        { label: "Tech", short: "tech", href: "#tech" },
+        { label: "Contact", short: "contact", href: "#contact" },
     ],
     hero: {
         kicker: "chomat.tech · v2 · MMXXVI",

--- a/src/styles/components/layout.css
+++ b/src/styles/components/layout.css
@@ -112,11 +112,18 @@
                 margin-top: 1.5rem;
                 padding-top: 1rem;
 
+                /* Stack the two CTAs vertically and full-width; the previous
+                   flex: 1 forced a 50/50 split which squashed "See what I'm
+                   building" into two awkward lines next to a half-empty
+                   "Resume.pdf". */
                 & .row-tight {
                     width: 100%;
+                    flex-direction: column;
+                    align-items: stretch;
+                    gap: 0.5rem;
                 }
                 & .btn {
-                    flex: 1;
+                    width: 100%;
                     justify-content: center;
                 }
             }

--- a/src/styles/components/layout.css
+++ b/src/styles/components/layout.css
@@ -149,7 +149,17 @@
             gap: 0.75rem;
 
             @media (max-width: 45rem) {
+                /* On phones the 3-up grid + fixed 260px height makes the thumbs
+                   pencil-thin. Switch to a 9:16 aspect ratio so they shrink to
+                   match the available column width. Higher specificity than the
+                   base .ph rule, so the inline --ph-h custom property still wins
+                   on desktop but is ignored here. */
                 gap: 0.5rem;
+
+                & .ph {
+                    height: auto;
+                    aspect-ratio: 9 / 16;
+                }
             }
         }
         & .now-small-grid {

--- a/src/styles/components/nav.css
+++ b/src/styles/components/nav.css
@@ -105,8 +105,8 @@
         & .mobile-menu {
             display: none; /* turned on by the @media below */
             position: fixed;
-            top: calc(1rem + env(safe-area-inset-top, 0px));
-            right: 1rem;
+            top: calc(0.875rem + env(safe-area-inset-top, 0px));
+            right: 0.875rem;
             z-index: 8;
 
             @media (max-width: 45rem) {
@@ -114,28 +114,44 @@
             }
 
             & .mobile-menu__trigger {
-                width: 2.75rem;
-                height: 2.75rem;
-                padding: 0;
                 appearance: none;
                 cursor: pointer;
-                border-radius: 50%;
+                display: inline-flex;
+                align-items: center;
+                gap: 0.5rem;
+                padding: 0.375rem 0.625rem 0.375rem 0.75rem;
+                border-radius: 9999rem;
                 border: 1px solid var(--line);
                 background: color-mix(in oklab, var(--surface) 92%, transparent);
                 backdrop-filter: blur(0.5rem);
                 color: var(--text);
-                box-shadow: var(--shadow);
-                display: flex;
-                align-items: center;
-                justify-content: center;
-                gap: 0.25rem;
+                box-shadow: 0 1px 0 var(--line-2);
+                font-family: var(--font-mono);
+                font-size: 0.625rem;
+                text-transform: uppercase;
+                letter-spacing: 0.08em;
+                line-height: 1;
+                transition:
+                    background 150ms ease,
+                    color 150ms ease,
+                    border-color 150ms ease,
+                    box-shadow 150ms ease;
+            }
+
+            & .mobile-menu__label {
+                display: inline-block;
+            }
+
+            & .mobile-menu__icon {
+                width: 0.75rem;
+                height: 0.625rem;
+                display: inline-flex;
                 flex-direction: column;
-                transition: background 150ms ease;
+                justify-content: space-between;
 
                 & span {
                     display: block;
-                    width: 1.125rem;
-                    height: 1.5px;
+                    height: 1.2px;
                     background: currentcolor;
                     border-radius: 1px;
                     transition:
@@ -145,60 +161,109 @@
             }
 
             &[data-open="true"] .mobile-menu__trigger {
+                background: var(--text);
+                color: var(--bg);
+                border-color: var(--text);
+                box-shadow: 0 2px 0 var(--line);
+            }
+            &[data-open="true"] .mobile-menu__icon {
                 & span:nth-child(1) {
-                    transform: translateY(0.4375rem) rotate(45deg);
+                    transform: translateY(0.25rem) rotate(45deg);
                 }
                 & span:nth-child(2) {
                     opacity: 0;
                 }
                 & span:nth-child(3) {
-                    transform: translateY(-0.4375rem) rotate(-45deg);
+                    transform: translateY(-0.25rem) rotate(-45deg);
                 }
             }
 
             & .mobile-menu__panel {
                 position: absolute;
-                top: calc(100% + 0.5rem);
+                top: calc(100% + 0.375rem);
                 right: 0;
-                min-width: 13rem;
+                min-width: 9.75rem;
                 background: color-mix(in oklab, var(--surface) 96%, transparent);
                 backdrop-filter: blur(0.625rem);
                 border: 1px solid var(--line);
-                border-radius: 1rem;
-                box-shadow: var(--shadow);
-                padding: 0.375rem;
-                margin: 0;
-                list-style: none;
+                border-radius: 1.125rem;
+                box-shadow: 0 0.625rem 1.375rem rgba(20, 18, 12, 0.1);
+                padding: 0.25rem;
                 display: none;
+                flex-direction: column;
+                gap: 0.125rem;
+            }
+            & .mobile-menu__list {
+                margin: 0;
+                padding: 0;
+                list-style: none;
+                display: flex;
+                flex-direction: column;
+                gap: 0.125rem;
+            }
+            & .mobile-menu__list a {
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                gap: 0.375rem;
+                padding: 0.4375rem 0.75rem;
+                border-radius: 9999rem;
+                font-family: var(--font-mono);
+                font-size: 0.6875rem;
+                text-transform: uppercase;
+                letter-spacing: 0.06em;
+                text-decoration: none;
+                color: var(--muted);
+                background: transparent;
+                transition:
+                    background 150ms ease,
+                    color 150ms ease;
 
-                & li + li {
-                    margin-top: 0.125rem;
-                }
-
-                & a {
-                    display: block;
-                    padding: 0.625rem 0.875rem;
-                    border-radius: 0.625rem;
-                    font-family: var(--font-mono);
-                    font-size: 0.75rem;
-                    text-transform: uppercase;
-                    letter-spacing: 0.06em;
+                &:hover,
+                &:focus-visible {
                     color: var(--text);
-                    text-decoration: none;
-
-                    &:hover,
-                    &:focus-visible {
-                        background: var(--surface-2);
-                    }
-                    &.resume-cta {
-                        background: var(--accent);
-                        color: var(--accent-ink);
-                    }
                 }
+
+                &.active {
+                    background: var(--text);
+                    color: var(--bg);
+                }
+            }
+            & .mobile-menu__dot {
+                display: inline-block;
+                width: 0.375rem;
+                height: 0.375rem;
+                border-radius: 50%;
+                background: var(--accent);
+                opacity: 0;
+                flex: 0 0 auto;
+            }
+            & .mobile-menu__list a.active .mobile-menu__dot {
+                opacity: 1;
+                background: var(--bg);
+            }
+            & .mobile-menu__text {
+                flex: 1;
+            }
+            & .mobile-menu__divider {
+                height: 1px;
+                background: var(--line-2);
+                margin: 0.25rem 0.5rem;
+            }
+            & .mobile-menu__resume {
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                padding: 0.375rem 0.75rem 0.5rem;
+                font-family: var(--font-mono);
+                font-size: 0.625rem;
+                color: var(--accent);
+                text-decoration: none;
+                letter-spacing: 0.04em;
             }
 
             &[data-open="true"] .mobile-menu__panel {
-                display: block;
+                display: flex;
             }
         }
     }
@@ -211,7 +276,8 @@
             & .pill-nav .active-pill,
             & .pill-nav .to-top,
             & .mobile-menu__trigger,
-            & .mobile-menu__trigger span {
+            & .mobile-menu__icon span,
+            & .mobile-menu__list a {
                 transition: none;
             }
         }

--- a/src/styles/components/nav.css
+++ b/src/styles/components/nav.css
@@ -151,9 +151,9 @@
 
                 & span {
                     display: block;
-                    height: 1.2px;
+                    height: 0.075rem;
                     background: currentcolor;
-                    border-radius: 1px;
+                    border-radius: 0.0625rem;
                     transition:
                         transform 200ms ease,
                         opacity 200ms ease;

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -1,6 +1,15 @@
 /* Document baseline. Loaded into @layer reset. */
 
 @layer reset {
+    /* Universal box-sizing so width: 100% + padding never overflows the
+       container. Without this .page-body and other padded blocks end up
+       wider than their flex parent on narrow viewports. */
+    *,
+    *::before,
+    *::after {
+        box-sizing: border-box;
+    }
+
     html,
     body {
         margin: 0;

--- a/src/styles/type.css
+++ b/src/styles/type.css
@@ -10,6 +10,7 @@
             letter-spacing: -0.02em;
             font-weight: 500;
             margin: 0;
+            overflow-wrap: break-word;
         }
         & .t-title {
             font-size: 1.0625rem;
@@ -17,6 +18,7 @@
             letter-spacing: -0.01em;
             font-weight: 500;
             margin: 0;
+            overflow-wrap: break-word;
         }
         & .t-body {
             font-size: 0.875rem;
@@ -24,6 +26,7 @@
             font-weight: 400;
             color: var(--text);
             margin: 0;
+            overflow-wrap: break-word;
 
             & > p {
                 margin: 0;
@@ -50,11 +53,15 @@
         /* V3 type overrides */
         &.v3 {
             & .t-mega {
-                font-size: clamp(3.5rem, 14vw, 8.25rem);
+                /* Floor lowered to 2rem so "Daniel Chomat*" fits the hero on
+                   ~320px-wide phones (Geist medium needs ~3rem of real estate
+                   per char × 13 chars; the 14vw curve takes over above 230px). */
+                font-size: clamp(2rem, 14vw, 8.25rem);
                 line-height: 0.86;
                 letter-spacing: -0.045em;
                 font-weight: 500;
                 margin: 0;
+                overflow-wrap: break-word;
             }
             & .kicker {
                 font-size: 0.75rem;


### PR DESCRIPTION
## Summary
- Replace the circular hamburger with a compact MENU/CLOSE pill that matches the design canvas' variant A no-navbar mobile homepage.
- Dropdown now uses short uppercase mono labels (now, exp, work, tech, contact) with an active-section indicator driven by the same IntersectionObserver pattern as the desktop NavCapsule.
- Resume.pdf separated by a divider, rendered in accent color with a ↓ glyph.

## Test plan
- [ ] On mobile width (≤45rem) the trigger reads MENU + hamburger, flips to CLOSE + X on tap.
- [ ] Dropdown highlights the section you're currently scrolled past (Now → Exp → Work → Tech → Contact).
- [ ] Resume.pdf row sits below a divider and opens `/resume.pdf`.
- [ ] Desktop pill nav (>45rem) is untouched.
- [ ] Escape, outside-click, and link clicks all close the panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile menu: active-section dot indicators, resume CTA, and a visible "menu" trigger label; nav items now support optional short labels for compact display.
* **Style**
  * Redesigned pill-shaped mobile trigger and refined mobile menu panel visuals and spacing.
  * Improved hero CTA and thumbnail layout on small screens.
  * Enhanced typography (better word-wrap, reduced mega minimum size) and added global box-sizing reset.
* **Documentation**
  * Updated fluid type guidance (removed one selector from clamp list).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DanielChomat/chomat.tech/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->