### PR TITLE
refine: post-merge polish — hero card, denser mobile, /experience footer

### DIFF
--- a/src/components/homepage/Hero.astro
+++ b/src/components/homepage/Hero.astro
@@ -54,4 +54,27 @@ const { hero } = SITE;
     .hero-status-muted {
         margin-left: 0.25rem;
     }
+
+    @media (max-width: 45rem) {
+        .hero-status {
+            align-items: flex-start;
+            gap: 0.5rem;
+            padding: 0.75rem 0.875rem;
+            background: color-mix(in oklab, var(--accent) 14%, var(--surface));
+            border: 1px solid color-mix(in oklab, var(--accent) 30%, var(--line));
+            border-radius: var(--radius);
+            box-shadow: var(--shadow);
+        }
+        .hero-status-dot {
+            margin-top: 0.3125rem;
+        }
+        .hero-status-muted {
+            display: block;
+            margin-left: 0;
+            margin-top: 0.125rem;
+            font-family: var(--font-mono);
+            font-size: 0.6875rem;
+            letter-spacing: 0.04em;
+        }
+    }
 </style>

--- a/src/components/homepage/SiteFooter.astro
+++ b/src/components/homepage/SiteFooter.astro
@@ -1,6 +1,11 @@
 ---
 import { SITE } from "../../data/site.ts";
 
+type Props = {
+    backToTopHref?: string;
+};
+
+const { backToTopHref = "#hero" } = Astro.props;
 const { footer } = SITE;
 ---
 
@@ -13,7 +18,7 @@ const { footer } = SITE;
             }
         </span>
         <span class="t-mono">
-            <a class="back-to-top" href="#hero">{footer.backToTop}</a>
+            <a class="back-to-top" href={backToTopHref}>{footer.backToTop}</a>
         </span>
     </div>
 </footer>

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -134,8 +134,7 @@ export const SITE = {
             },
         },
         wormholes: [
-            { label: "/lab — playground & experiments", href: "/lab" },
-            { label: "/uses — tools & setup", href: "/uses" },
+            { label: "/experience — the long version", href: "/experience" },
             { label: "/404 — yes really", href: "/404" },
         ],
     },

--- a/src/pages/experience.astro
+++ b/src/pages/experience.astro
@@ -1,5 +1,6 @@
 ---
 import { getCollection, render } from "astro:content";
+import SiteFooter from "../components/homepage/SiteFooter.astro";
 import MobileMenu from "../components/nav/MobileMenu.astro";
 import NavCapsule from "../components/nav/NavCapsule.astro";
 import SoundToggle from "../components/nav/SoundToggle.astro";
@@ -39,7 +40,7 @@ const rendered = await Promise.all(
         <NavCapsule items={copy.nav} />
         <MobileMenu items={copy.nav} />
         <div class="page">
-            <main class="page-body experience-page">
+            <main id="top" class="page-body experience-page">
                 <nav class="exp-crumbs" aria-label="Breadcrumb">
                     <a
                         class="t-mono muted exp-crumb-home"
@@ -201,6 +202,7 @@ const rendered = await Promise.all(
                         }
                     </ol>
                 </section>
+                <SiteFooter backToTopHref="#top" />
             </main>
         </div>
     </div>

--- a/src/styles/components/layout.css
+++ b/src/styles/components/layout.css
@@ -33,7 +33,7 @@
             gap: 6.25rem;
 
             @media (max-width: 45rem) {
-                gap: 3.75rem;
+                gap: 2.5rem;
             }
         }
         & .section-mark {


### PR DESCRIPTION
## Summary
Four small follow-ups that fell out of the variant-A pass:

- **Mobile hero status card** — wraps the existing row in a teal-tinted card on mobile to match the design canvas' MobileHero; the \"Open to…\" muted text drops onto its own mono sub-line.
- **Denser mobile rhythm** — \`.section-stack\` gap shrinks from 3.75rem → 2.5rem at \`max-width: 45rem\`.
- **/experience back-to-top** — SiteFooter takes an optional \`backToTopHref\` prop (defaults to \`#hero\`); /experience mounts it with \`#top\` and adds \`id=\"top\"\` to its \`<main>\`.
- **Live wormholes** — drop \`/lab\` and \`/uses\` (no pages / designs yet); add \`/experience\` so the list points only at routes that resolve.

## Test plan
- [ ] Mobile (≤45rem): hero status renders as a teal card with a sub-line for the muted text; sections feel tighter; menu still works.
- [ ] Desktop: hero status row unchanged; section gap unchanged; nav capsule unchanged.
- [ ] /experience: clicking \"↑ back to top\" scrolls to the page top.
- [ ] Wormhole list at the bottom of /#contact shows only \`/experience\` and \`/404\`, and both navigate without 404ing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added footer to the experience page with back-to-top navigation
  * Back-to-top link is now customizable per page

* **UI Improvements**
  * Enhanced mobile responsiveness with optimized hero section layout on small screens
  * Reduced spacing and improved visual hierarchy for better readability on mobile devices

* **Updates**
  * Revised navigation links; experience section replaces lab and uses sections

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DanielChomat/chomat.tech/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->