### PR TITLE
chore(skills): project-tailored Claude Code skills

### DIFF
--- a/.claude/skills/add-experience/SKILL.md
+++ b/.claude/skills/add-experience/SKILL.md
@@ -16,23 +16,38 @@ state on the timeline.
 
 ### A. New entry (new company)
 
-Required info to ask the user:
+**Schema-required (Zod will reject the build without these):**
 
-- **Slug** (filename without `.mdx`, kebab-case).
-- **Company** — display name.
-- **Title** — role (e.g., "Mobile Engineer").
-- **Interval(s)** — start + end dates. `end: present` if it's the
-  current role. Partners Bank in this repo has two intervals because
-  the user left and came back — that's the canonical case for using
-  more than one.
-- **Location** — e.g., "Prague, CZ", "Remote".
-- **Tech** — list of stack pills.
-- **NDA?** — boolean; default `false`. Sets sticker behaviour.
-- **Summary** — one-sentence headline (shown on homepage card).
-- **Tint** — `butter | sage | rose | sky | lavender | teal | ""`.
-  Default `""`. Use `teal` for the "currently here" entry to make the
-  card stand out on both the homepage and `/experience`.
-- **Body** — 2–4 sentences of prose, MDX. Don't repeat the summary.
+- **company** — display name.
+- **title** — role (e.g., "Mobile Engineer").
+- **intervals** — at least one `{ start, end }` pair. `end: present`
+  if it's the current role. Partners Bank in this repo has two
+  intervals because the user left and came back — that's the
+  canonical case for using more than one.
+- **summary** — one-sentence headline (shown on homepage card).
+
+Plus:
+
+- **Slug** — filename without `.mdx`, kebab-case. Not a frontmatter
+  field but you can't write the file without picking one.
+- **Body** — MDX prose below the frontmatter, 2–4 sentences. Don't
+  repeat the summary.
+
+**Worth asking anyway (defaults exist, but the user usually cares):**
+
+- **location** — e.g., "Prague, CZ", "Remote". Optional; the homepage
+  card and `/experience` chapter both show it when present.
+- **tech** — list of stack pills. Defaults to `[]`. An empty tech row
+  looks incomplete on the chapter card.
+- **tint** — `butter | sage | rose | sky | lavender | teal | ""`.
+  Default `""`. Use `teal` for the "currently here" entry to make
+  the card stand out on both the homepage and `/experience`.
+
+**Pure optional (skip unless the user asks):**
+
+- **nda** — boolean; default `false`. Sets sticker behaviour.
+- **order** — sorting; default `0`. The current role is `0` and
+  earlier roles grow downward.
 
 ### B. New interval on an existing entry
 

--- a/.claude/skills/add-experience/SKILL.md
+++ b/.claude/skills/add-experience/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: add-experience
+description: Scaffold a new experience MDX entry under src/content/experience/ with valid frontmatter matching the Zod schema in src/content/config.ts. Use when the user wants to add a job/role/freelance interval (or a new interval to an existing entry).
+---
+
+# /add-experience
+
+Scaffold an experience entry for the Content Collection at
+`src/content/experience/`. The schema in `src/content/config.ts`
+(`experience`) requires `intervals` as an array of
+`{ start: Date, end: Date | "present" }` — that's what powers the
+`isCurrent()` / `formatIntervals()` helpers and the "currently here"
+state on the timeline.
+
+## Two flows
+
+### A. New entry (new company)
+
+Required info to ask the user:
+
+- **Slug** (filename without `.mdx`, kebab-case).
+- **Company** — display name.
+- **Title** — role (e.g., "Mobile Engineer").
+- **Interval(s)** — start + end dates. `end: present` if it's the
+  current role. Partners Bank in this repo has two intervals because
+  the user left and came back — that's the canonical case for using
+  more than one.
+- **Location** — e.g., "Prague, CZ", "Remote".
+- **Tech** — list of stack pills.
+- **NDA?** — boolean; default `false`. Sets sticker behaviour.
+- **Summary** — one-sentence headline (shown on homepage card).
+- **Tint** — `butter | sage | rose | sky | lavender | teal | ""`.
+  Default `""`. Use `teal` for the "currently here" entry to make the
+  card stand out on both the homepage and `/experience`.
+- **Body** — 2–4 sentences of prose, MDX. Don't repeat the summary.
+
+### B. New interval on an existing entry
+
+The user came back to a previous employer. Don't create a new file;
+*append* an interval to the existing entry's frontmatter:
+
+```yaml
+intervals:
+    - start: 2021-09-01
+      end: 2023-08-31
+    - start: 2025-09-01
+      end: present
+```
+
+If the new interval is current, also set `tint: teal` (so the
+"currently here" treatment moves to this entry) and confirm with the
+user before flipping the tint on any *other* entry off.
+
+## Writing the file
+
+Create `src/content/experience/<slug>.mdx`:
+
+```mdx
+---
+company: <Display name>
+title: <Role>
+intervals:
+    - start: YYYY-MM-DD
+      end: YYYY-MM-DD            # or `present`
+location: "<City, CC>"            # quote if it has a comma
+tech:
+    - <pill>
+    - <pill>
+nda: false
+summary: "<one-line summary>"
+tint: ""                          # "teal" if currently here
+order: 0
+---
+
+<prose body>
+```
+
+Dates are real YAML dates (no quotes), `present` is the literal
+unquoted word. `order` should grow from the current role downward
+— the homepage and `/experience` sort by it.
+
+## After writing
+
+1. `yarn check:astro` — catches schema drift immediately.
+2. Both the homepage Experience section and `/experience` will pick
+   the entry up from the collection. No manual wiring.
+3. If you set this entry as currently-here, the timeline jump-nav on
+   `/experience` will highlight it and the "Currently here" sticker
+   and StatusPill light up automatically — driven by
+   `isCurrent(intervals)`.
+
+## Anti-patterns
+
+- Don't put company copy in `src/data/site.ts` — that file is for
+  site-level prose only. Experience copy lives in the MDX.
+- Don't add the entry to a hand-written list anywhere; both consumers
+  read the collection.
+- Don't change `order` without coordinating with the user — it
+  re-shuffles the homepage card row.

--- a/.claude/skills/add-project/SKILL.md
+++ b/.claude/skills/add-project/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: add-project
+description: Scaffold a new project MDX entry under src/content/projects/ with valid frontmatter that matches the Zod schema in src/content/config.ts. Use when the user wants to add a portfolio project (shipped, building, archived, or private).
+---
+
+# /add-project
+
+Scaffold a new project for the Content Collection at
+`src/content/projects/`. The frontmatter must match the Zod schema in
+`src/content/config.ts` (`projects`); if you skip a required field
+the build will fail with a useful error, but it's faster to get it
+right the first time.
+
+## Required information
+
+Ask the user only for what you can't reasonably infer:
+
+- **Slug** (filename without `.mdx`). Use kebab-case. Becomes the
+  entry id.
+- **Title** — the displayed name (e.g., "Walletory").
+- **Tagline** — one short line (8–12 words).
+- **Status** — one of `shipped`, `building`, `archived`, `private`.
+- **Kind** — `personal` or `client`.
+- **Year** — short label shown on the card (e.g., `2023`, `21–23`).
+- **Tech** — array of pills (e.g., `["React Native", "TypeScript"]`).
+- **Body** — 2–4 sentences of prose for the MDX body.
+
+If `kind=client`, also ask for **client** (display name) and whether
+it's NDA'd (`nda: true`) — sets the privacy/sticker behaviour.
+
+## Optional fields with sensible defaults
+
+- `bentoSize`: `"sm" | "md" | "lg" | "xl"` — default `"sm"`. The
+  homepage Work bento uses `sm` (col-4) by default; `lg` is the wide
+  feature card. Only bump it if the user asks for a featured layout.
+- `featured`: boolean, default `false`. Set `true` only for the
+  homepage Hero/Now featured slot.
+- `sticker`: `{ tone: "butter|sage|rose|sky|lavender|teal", text: string }`.
+  Skip unless the user wants a corner sticker (e.g., "NDA",
+  "ARCHIVED", "STILL UP").
+- `homeLabel` — override the card title shown on the homepage if it
+  differs from `title`.
+- `order` — sorting; default `0`. Lower numbers come first.
+- `startDate` / `endDate` — ISO dates; only needed if you want the
+  homepage to sort/group by time.
+
+## Schema source of truth
+
+Open `src/content/config.ts` and follow the `projects` collection
+schema exactly. If the schema has changed, trust the schema, not this
+doc.
+
+## Writing the file
+
+Create `src/content/projects/<slug>.mdx` with this shape:
+
+```mdx
+---
+title: <Title>
+tagline: "<one-liner>"
+status: <shipped|building|archived|private>
+kind: <personal|client>
+client: "<Client Name>"   # only if kind=client
+year: "<short>"
+tech:
+    - <pill>
+    - <pill>
+bentoSize: sm
+featured: false
+sticker:
+    tone: <tone>
+    text: <STICKER>
+order: 0
+---
+
+<prose body — 2–4 sentences>
+```
+
+Quote string values that contain `:`, `#`, or smart quotes. Drop any
+optional field you don't need rather than leaving it empty — the
+schema is strict and an empty string is *not* the same as omitting.
+
+## After writing
+
+1. Run `yarn check:astro` — it will surface schema errors immediately.
+2. If the project should appear on the homepage Work bento right
+   away, no further wiring is needed; the section reads the
+   collection. If it should be the hero/featured tile, set
+   `featured: true` and confirm with the user that they want it
+   promoted ahead of the current featured project.
+3. Tell the user the file path and the homepage location it'll
+   appear (Work bento row N, or featured slot).
+
+## Anti-patterns
+
+- Don't add a project to a hand-written list anywhere — the homepage
+  reads the collection.
+- Don't invent fields that aren't in the schema; if the user wants
+  metadata that doesn't exist, propose extending the schema in
+  `src/content/config.ts` first and stop.

--- a/.claude/skills/add-project/SKILL.md
+++ b/.claude/skills/add-project/SKILL.md
@@ -11,28 +11,43 @@ Scaffold a new project for the Content Collection at
 the build will fail with a useful error, but it's faster to get it
 right the first time.
 
-## Required information
+## Schema-required (Zod will reject the build without these)
 
-Ask the user only for what you can't reasonably infer:
+Per `src/content/config.ts` (`projects` collection):
 
-- **Slug** (filename without `.mdx`). Use kebab-case. Becomes the
-  entry id.
-- **Title** — the displayed name (e.g., "Walletory").
-- **Tagline** — one short line (8–12 words).
-- **Status** — one of `shipped`, `building`, `archived`, `private`.
-- **Kind** — `personal` or `client`.
-- **Year** — short label shown on the card (e.g., `2023`, `21–23`).
-- **Tech** — array of pills (e.g., `["React Native", "TypeScript"]`).
-- **Body** — 2–4 sentences of prose for the MDX body.
+- **title** — displayed name (e.g., "Walletory").
+- **tagline** — one short line (8–12 words).
+- **status** — one of `shipped`, `building`, `archived`, `private`.
+- **kind** — `personal` or `client`.
 
-If `kind=client`, also ask for **client** (display name) and whether
-it's NDA'd (`nda: true`) — sets the privacy/sticker behaviour.
+Plus you need:
 
-## Optional fields with sensible defaults
+- **Slug** — filename without `.mdx`, kebab-case. Becomes the entry
+  id. Not a frontmatter field, but you can't write the file without
+  picking one.
+- **Body** — MDX prose, 2–4 sentences. Not in frontmatter; it's the
+  content below the `---` block.
 
-- `bentoSize`: `"sm" | "md" | "lg" | "xl"` — default `"sm"`. The
-  homepage Work bento uses `sm` (col-4) by default; `lg` is the wide
-  feature card. Only bump it if the user asks for a featured layout.
+## Worth asking anyway (defaults exist, but the user usually has an opinion)
+
+- **tech** — array of pills (`["React Native", "TypeScript"]`).
+  Defaults to `[]`. An empty tech list looks anaemic on the homepage
+  card.
+- **year** — short label on the card (`2023`, `21–23`). Optional.
+  Cards without a year look incomplete.
+
+If `kind=client`, also ask:
+
+- **client** — display name. Optional in the schema but the card's
+  meta line reads weirdly without it for client work.
+- **nda** — `true` if the project is NDA'd. Defaults to `false`.
+  Affects sticker behaviour.
+
+## Pure optional fields (skip unless the user asks)
+
+- `bentoSize`: `"sm" | "md" | "lg" | "xl"` — default `"sm"` (col-4).
+  `"lg"` is the wide feature card. Only bump if the user asks for a
+  featured layout.
 - `featured`: boolean, default `false`. Set `true` only for the
   homepage Hero/Now featured slot.
 - `sticker`: `{ tone: "butter|sage|rose|sky|lavender|teal", text: string }`.
@@ -43,6 +58,9 @@ it's NDA'd (`nda: true`) — sets the privacy/sticker behaviour.
 - `order` — sorting; default `0`. Lower numbers come first.
 - `startDate` / `endDate` — ISO dates; only needed if you want the
   homepage to sort/group by time.
+- `links.{live, repo, caseStudy}` — outbound URLs; URL-validated by
+  Zod, so `live: "TBD"` will break the build. Omit instead.
+- `cover` — image path. Skip until the project has art.
 
 ## Schema source of truth
 

--- a/.claude/skills/add-section/SKILL.md
+++ b/.claude/skills/add-section/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: add-section
+description: Scaffold a new homepage section under src/components/homepage/ — creates the .astro file with the project's standard structure, a typed copy block in SITE, registers it in src/pages/index.astro, and optionally adds a nav entry. Use when the user wants a new top-level homepage section (a peer of Hero / Now / Experience / Work / Tech / Companies / Contact).
+---
+
+# /add-section
+
+Scaffold a peer section for the homepage. Follows the conventions in
+`AGENTS.md` and the existing sections under
+`src/components/homepage/`.
+
+## Required information
+
+Ask the user for:
+
+- **Section name** (PascalCase, e.g., `Writing`). This becomes the
+  component filename and the SITE key (lowercased).
+- **Section anchor** (kebab-case, e.g., `writing`). Used as the
+  section `id` and the nav `href`.
+- **Number** (e.g., `§06`) — shown in the section-mark rail and
+  kicker. Increment from the existing sections; today's max is `§05`
+  (Contact).
+- **Kicker** — short uppercase label (e.g., `Writing`).
+- **Heading** — split into `headingMain` + `headingMuted` so the
+  muted half can wrap onto a second visual line, matching every
+  other section.
+- **Intro / body** — what the section actually does.
+- **Add to nav?** — boolean. If yes, append to `SITE.nav` with both
+  `label` and `short` fields (the short form is what the mobile pill
+  menu uses).
+
+## Files to touch
+
+1. **`src/data/site.ts`** — add a typed copy block:
+
+   ```ts
+   writing: {
+       number: "§06",
+       kicker: "Writing",
+       headingMain: "Notes,",
+       headingMuted: "mostly half-formed.",
+       intro: "…",
+   },
+   ```
+
+   If the section needs lists or sub-items, follow the shape used by
+   `now`, `experience`, `work`, `tech`, or `contact` for inspiration
+   — these are the canonical patterns. Don't invent a new shape for
+   the same job.
+
+2. **`src/components/homepage/<Name>.astro`** — match the existing
+   sections' shape:
+
+   ```astro
+   ---
+   import { SITE } from "../../data/site.ts";
+   import Kicker from "../primitives/Kicker.astro";
+
+   const { writing: copy } = SITE;
+   ---
+
+   <section id="writing">
+       <div class="section-mark">
+           <span class="lineno">{copy.number}</span>
+       </div>
+       <header>
+           <div class="row row-between row-baseline">
+               <Kicker>{copy.kicker}</Kicker>
+               <!-- optional link/meta to the right -->
+           </div>
+           <h2 class="t-heading section-heading">
+               <span>{copy.headingMain}</span>{" "}
+               <span class="muted">{copy.headingMuted}</span>
+           </h2>
+           <p class="t-body muted section-intro">{copy.intro}</p>
+           <div class="section-divider"></div>
+       </header>
+
+       <!-- section body — bento, list, cards, whatever fits -->
+   </section>
+
+   <style>
+       .section-heading {
+           margin-top: 0.375rem;
+       }
+       .section-intro {
+           margin-top: 0.375rem;
+           max-width: 36.25rem;
+       }
+   </style>
+   ```
+
+   - Use `<h2>` for the section heading (not `<h3>`).
+   - Use `<article>` for each repeated item if the section is a list.
+   - **No inline `style=""`** — scoped `<style>` only. The one
+     allowed exception is dynamic CSS custom properties (e.g.,
+     `style={\`--ph-h: ${heightRem};\`}`).
+   - Section-local visual tweaks go in this `<style>` block. Design
+     tokens stay in `src/styles/components/*.css`.
+
+3. **`src/pages/index.astro`** — import + render in the section
+   stack:
+
+   ```astro
+   import Writing from "../components/homepage/Writing.astro";
+   ```
+
+   Place the `<Writing />` element inside `<div class="section-stack">`
+   at the position the user wants. If unclear, default to *before*
+   Contact (the closing section).
+
+4. **`src/data/site.ts` → `nav`** (only if user asked to add to nav):
+
+   ```ts
+   { label: "Writing", short: "writing", href: "#writing" },
+   ```
+
+## After writing
+
+1. `yarn check:astro` — verifies imports + typed copy access.
+2. `yarn build` — confirms the section renders in the static output.
+3. If the section is in the nav, scroll the mobile menu to verify the
+   short label fits. The mobile pill panel is narrow.
+
+## Don't
+
+- Don't add a section-specific stylesheet under
+  `src/styles/components/` unless multiple sections need the same
+  rules. Local tweaks belong in the scoped `<style>` block.
+- Don't add a tablet breakpoint. The repo uses a single mobile
+  breakpoint at `45rem` (per AGENTS.md).
+- Don't fight the `.page-body` `max-width: 80rem` cap. The section
+  lives inside that container.
+- Don't add `min-height` to cards to enforce row alignment — CSS
+  Grid handles that.

--- a/.claude/skills/astro/SKILL.md
+++ b/.claude/skills/astro/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: astro
+description: Astro framework reference, but project-aware for chomat.tech v2. Use when a question is about Astro itself — CLI commands, project structure, Content Collections, adapters, hydration islands, view transitions — and you want the answer routed through this repo's conventions (Yarn, Biome, vanilla CSS with @layer, MDX 4, no React). Defers to AGENTS.md for hard rules and to docs.astro.build for everything else.
+---
+
+# Astro on chomat.tech v2
+
+A reference skill for working with the Astro framework *in this
+repo*. Generic Astro tutorials default to `npx`, npm, ESLint, and
+React islands; chomat.tech v2 uses Yarn, Biome, and vanilla `<script>`
+islands. Lead with the project's choices; fall back to upstream docs
+for everything else.
+
+**Source of truth:** [AGENTS.md](../../../AGENTS.md) for hard rules,
+[docs.astro.build](https://docs.astro.build) for API surface.
+
+---
+
+## What's installed
+
+- **Astro 5.x** — static generation, Content Collections,
+  `<ClientRouter />`. Don't bump major.
+- **`@astrojs/mdx@^4`** — MDX 4. Bumping to 5 requires Astro 6;
+  don't do it in isolation.
+- **`@astrojs/sitemap`** — generates `sitemap-index.xml` at build.
+- **`@fontsource-variable/geist`**, **`@fontsource-variable/geist-mono`**
+  — self-hosted variable fonts. No CDN.
+- **TypeScript strict** everywhere.
+- **No React, no Solid, no Preact.** Interactivity = vanilla
+  `<script>` blocks inside `.astro` files.
+
+---
+
+## Project structure (the real one)
+
+```
+src/
+├── components/
+│   ├── homepage/      One per section (Hero, Now, Experience, Work,
+│   │                  Tech, Companies, Contact, SiteFooter)
+│   ├── nav/           NavCapsule, MobileMenu, SoundToggle
+│   └── primitives/    Pill, Kicker, Placeholder, HandArrow, …
+├── content/
+│   ├── config.ts      Zod schemas for projects/experience/
+│   │                  companies/about
+│   ├── projects/*.mdx
+│   ├── experience/*.mdx
+│   ├── companies/*.json
+│   └── about/index.mdx
+├── data/
+│   ├── site.ts        All site-level prose (hero, sections, footer)
+│   └── format.ts      formatIntervals, isCurrent, bentoCol,
+│                      stickerClass, tintClass
+├── layouts/
+│   └── BaseLayout.astro
+├── pages/
+│   ├── index.astro    Homepage (composes the sections)
+│   ├── 404.astro      /404
+│   └── experience.astro   /experience long-form
+└── styles/
+    ├── global.css     @layer order + @import partials
+    ├── reset.css
+    ├── tokens.css     .wf root + .wf.pal-newsprint + .wf.v3
+    ├── type.css
+    ├── utilities.css
+    └── components/    card / pill / controls / nav / layout /
+                        decorations
+```
+
+---
+
+## CLI commands — use the wired-up scripts
+
+The scripts in `package.json` are what CI and the dev workflow use.
+Prefer them over raw `npx`:
+
+| Goal | Use this | Not this |
+|---|---|---|
+| Dev server | `yarn dev` | `npx astro dev` |
+| Production build | `yarn build` | `npx astro build` |
+| Type / Astro diagnostics | `yarn check:astro` | `npx astro check` |
+| TypeScript only | `yarn check:ts` | `npx tsc --noEmit` |
+| Generate types after content change | `yarn check:astro` (it syncs) | `npx astro sync` |
+| Lint + format | `npx biome check .` | (no `astro lint` exists) |
+| Pre-push gate | `/verify` skill (covers all of the above) | manual sequence |
+
+`npx astro add <integration>` is fine for one-shot integration
+installs — it rewrites `astro.config.mjs` and adds the dep. But
+afterwards, all subsequent builds go through `yarn`.
+
+---
+
+## Content Collections (the actual schema)
+
+Defined in `src/content/config.ts`. Four collections:
+
+- **`projects`** — portfolio entries under `src/content/projects/*.mdx`.
+  Required: `title`, `tagline`, `status`, `kind`. See `/add-project`.
+- **`experience`** — roles under `src/content/experience/*.mdx`.
+  Required: `company`, `title`, `intervals` (min 1), `summary`.
+  See `/add-experience`. Partners Bank uses two intervals (left,
+  came back).
+- **`companies`** — logo-strip data, JSON files.
+- **`about`** — bio + languages, MDX.
+
+Loaders use the `glob()` loader from `astro/loaders`. MDX bodies
+are rendered via `const { Content } = await render(entry)`.
+
+If you change a schema in `config.ts`, run `yarn check:astro` —
+it regenerates types in `.astro/`. The dev server picks them up
+automatically.
+
+---
+
+## Astro-specific gotchas (from AGENTS.md, surfaced here too)
+
+- **`<script>` blocks compile to ES modules.** They're deferred by
+  default. **Don't wrap their bodies in `DOMContentLoaded`** —
+  the document is already parsed when the module runs.
+- **`NodeListOf<T>` doesn't implement `Symbol.iterator`** under
+  Astro's TS lib config. Wrap in `Array.from(…)` before `for…of`.
+- **`<Image>` is the canonical image path.** Sharp is auto-installed.
+  Pass explicit dimensions; the component handles `loading="lazy"`
+  for below-fold images.
+- **CSS custom properties cannot be used in `@media` conditions.**
+  No browser supports `@media (max-width: var(--bp))`. Use a
+  literal `45rem`.
+- **Native CSS nesting only** — no preprocessor. `& .child`,
+  `& > .child`, `&.state`, `&[data-x]`, `&:hover`.
+
+---
+
+## Adding things
+
+| Want to add | Skill | Notes |
+|---|---|---|
+| A homepage section | `/add-section` | Scaffolds the .astro file, SITE copy block, and registers in index.astro. |
+| A portfolio project | `/add-project` | Builds an MDX entry against the projects schema. |
+| A role / employer | `/add-experience` | Builds an MDX entry; the Partners Bank "came back" pattern is documented. |
+| A new top-level page (peer of /experience, /404) | No skill — copy `src/pages/experience.astro` as a starting point. Mount NavCapsule + MobileMenu + SoundToggle. |
+| An integration (e.g., `@astrojs/cloudflare`) | `npx astro add <name> --yes`, then re-run `yarn check:astro` to sync types. |
+
+---
+
+## Don't do (project-specific bans, source: AGENTS.md)
+
+- Don't add React, Preact, or any React-based build tool
+  (`@react-pdf/renderer`). Use Puppeteer for the planned
+  `/resume.pdf`.
+- Don't bump `@astrojs/mdx` to 5 without bumping Astro to 6.
+- Don't switch to pnpm; Yarn is the package manager.
+- Don't add a tablet breakpoint — the repo uses one mobile
+  breakpoint at `45rem`.
+- Don't add inline `style=""` (one exception: dynamic CSS custom
+  properties).
+
+---
+
+## When you need more
+
+- **API reference**: [docs.astro.build](https://docs.astro.build) —
+  the upstream docs are authoritative for anything not pinned here.
+- **Config reference**: [astro config reference](https://docs.astro.build/en/reference/configuration-reference/).
+- **LLM-friendly index**: [docs.astro.build/llms.txt](https://docs.astro.build/llms.txt).
+
+When upstream Astro guidance contradicts this repo (npx vs yarn,
+React islands vs vanilla scripts, etc.), AGENTS.md wins.

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -114,7 +114,94 @@ yarn build            # production build, surfaces MDX schema errors
 Both should pass before you ship. (Use `/verify` for this — it also
 filters Biome's `noUnusedImports` false positives on `.astro` files.)
 
-### 9. CodeRabbit timing
+### 9. Focus states (folded in from Vercel web-interface-guidelines)
+
+Every interactive element needs a *visible* focus indicator. The
+canonical rules:
+
+- Never `outline: none` without a replacement focus style.
+- Prefer `:focus-visible` over `:focus` — avoids the focus ring
+  flashing on plain mouse clicks.
+- For compound controls (e.g., a pill button with an icon), use
+  `:focus-within` on the parent so focus state composes.
+
+Scan the diff for any `outline:` declarations and any new
+`<button>`, `<a>`, or focusable custom control. If the diff adds a
+new interactive element without a `:focus-visible` rule, flag it.
+
+### 10. Animation discipline
+
+From AGENTS.md and the Vercel ruleset:
+
+- `transition: all` is banned — list properties explicitly. A real
+  `transition` line names what's animating (e.g.,
+  `transition: transform 180ms ease, opacity 180ms ease`).
+- Animate only `transform` and `opacity` where possible — they stay
+  on the compositor. Avoid animating `width`, `height`, `top`,
+  `left`, `background`.
+- `prefers-reduced-motion: reduce` block present for any rule with
+  a `transition` (AGENTS.md hard rule).
+- For SVG glyphs that rotate or scale, put the transform on a
+  `<g>` wrapper with `transform-box: fill-box; transform-origin: center`.
+
+### 11. Typography polish
+
+Easy to miss in copy and class names but cheap to fix:
+
+- `…` not `...` (real ellipsis, not three dots). Search the diff
+  for `\.\.\.` in user-visible strings (skip URLs and code).
+- `"…"` curly quotes for prose, not `"…"` straight quotes. The
+  homepage copy already uses them; new copy should match.
+- Non-breaking spaces in compound terms: `⌘&nbsp;K`, `10&nbsp;MB`,
+  brand names that shouldn't break (`React&nbsp;Native`,
+  `Partners&nbsp;Bank` if it ever wraps oddly).
+- `text-wrap: balance` on headings — prevents lonely-word widows
+  on the last line. Already worth applying to `.t-mega`,
+  `.t-heading`, and section heading splits if not already.
+- `font-variant-numeric: tabular-nums` on columns of numbers
+  (year columns in /experience, the IGIC mini-UI numbers).
+- Loading/progress strings end with `…`: "Loading…", "Saving…".
+
+### 12. Image dimensions (CLS prevention)
+
+When any `<img>` ships (e.g., when the Placeholder is replaced
+with real art):
+
+- Explicit `width` and `height` attributes — prevents Cumulative
+  Layout Shift.
+- Below-the-fold images: `loading="lazy"`.
+- Above-the-fold (hero, featured Now): `fetchpriority="high"` and
+  consider preloading.
+- Astro's `<Image>` component handles most of this; flag any raw
+  `<img>` tags in the diff that don't.
+
+### 13. Touch & mobile interaction
+
+Cheap one-time adds that the design system doesn't already have:
+
+- `touch-action: manipulation` on tap-to-act elements (kills the
+  300ms double-tap zoom delay on iOS).
+- `-webkit-tap-highlight-color` set intentionally (default is grey;
+  brand-aligned or transparent reads better).
+- `overscroll-behavior: contain` on the mobile menu panel so
+  scrolling inside it doesn't bubble to the page.
+
+### 14. Performance hints
+
+- No layout-reading APIs (`getBoundingClientRect`, `offsetWidth`,
+  `offsetHeight`, `scrollTop`) inside render or rAF without
+  batching. The existing IntersectionObserver pattern in
+  `NavCapsule.astro` and `MobileMenu.astro` is the right model.
+- Critical fonts (Geist Variable, Geist Mono Variable) should be
+  preloaded with `<link rel="preload" as="font" type="font/woff2"
+  crossorigin>` and have `font-display: swap` set. Check the
+  Astro-emitted `<head>` once before shipping a typography change.
+- For any future large list (>50 items), virtualize with
+  `content-visibility: auto` or a virtualization helper. The
+  current homepage tops out at ~12 projects so this is forward-
+  looking.
+
+### 15. CodeRabbit timing
 
 After opening the PR, **wait for CodeRabbit before merging.** Quote
 from AGENTS.md: "merging before the bot finishes logs 'Review
@@ -126,8 +213,9 @@ this on PR #57.
 
 ## Output
 
-Group findings by category (Semantic HTML / a11y / Sizing / Inline
-styles / Workflow). For each one:
+Group findings by category (Semantic HTML / a11y / Focus / Sizing /
+Inline styles / Animation / Typography / Images / Touch /
+Performance / Workflow). For each one:
 
 - File:line.
 - The rule it violates.

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -29,7 +29,9 @@ AGENTS.md: "Prefer the correct element over a `<div>` with classes."
 CodeRabbit reliably catches:
 
 - `<div>` wrappers around lists of links → should be
-  `<nav aria-label="…">`. Examples already caught on this repo:
+  `<nav aria-label="…">`. Historical examples on this repo (verify
+  against current code before quoting them at the user — these
+  files have evolved):
   - The mobile menu dropdown panel (was `<div>`, now `<nav>`).
   - The `/experience` breadcrumb row (was `<div class="exp-crumbs">`).
   - The `/experience` timeline jump-nav (was `<aside>`).

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: review
+description: Pre-CodeRabbit local review for chomat.tech v2 PRs. Reviews the current branch against the rules in AGENTS.md and the patterns CodeRabbit has been catching on this repo (semantic HTML landmarks, rem-first sizing, accessibility attributes). Use before `gh pr create` so the first CodeRabbit pass has less to find — and so you're not blocked when CodeRabbit is rate-limited.
+---
+
+# /review (chomat.tech v2)
+
+A local pre-flight review. CodeRabbit is the authoritative reviewer
+on this repo, but it's been rate-limited mid-session (see PR #57)
+and tends to find the same handful of things — most of which a
+local pass can catch first.
+
+## Scope
+
+The current branch's diff against `V2-redesign`:
+
+```bash
+git diff "$(git merge-base HEAD V2-redesign)"..HEAD
+```
+
+If the user passes a PR number, fetch its diff via
+`gh pr diff <n>` instead.
+
+## What to check, in priority order
+
+### 1. Semantic HTML landmarks
+
+AGENTS.md: "Prefer the correct element over a `<div>` with classes."
+CodeRabbit reliably catches:
+
+- `<div>` wrappers around lists of links → should be
+  `<nav aria-label="…">`. Examples already caught on this repo:
+  - The mobile menu dropdown panel (was `<div>`, now `<nav>`).
+  - The `/experience` breadcrumb row (was `<div class="exp-crumbs">`).
+  - The `/experience` timeline jump-nav (was `<aside>`).
+- `<div>` wrappers around content items that should be `<article>`
+  (projects, experience chapters, contact cards).
+- Section headings that should be `<h2>` not `<h3>` (the homepage
+  Experience cards' company name is `<h3>` — that one's correct
+  because the section header is `<h2>`).
+- Buttons that should be `<button type="button">` not styled
+  `<div>`s; expose state via `aria-pressed` / `aria-expanded`.
+
+### 2. Accessibility on visually-collapsed text
+
+If any text uses `display: none` or `visibility: hidden` at the
+mobile breakpoint, the surrounding interactive element needs an
+explicit `aria-label` so screen readers still announce the
+destination. CodeRabbit caught this on `.exp-crumb-home` — the home
+label is hidden on mobile, so the anchor needs
+`aria-label={copy.homeCrumb}`.
+
+Also: decorative glyphs (←, ↓, ✕, →) inside interactive elements
+should have `aria-hidden="true"` so they're not double-announced.
+
+### 3. `aria-current` on in-page active links
+
+When a nav exposes "which item is current," the active link should
+carry `aria-current` — `"page"` for cross-page nav, `"true"` for
+in-page jump nav (like `/experience`'s timeline). CodeRabbit caught
+this on the `.exp-jumpnav-link.current`.
+
+### 4. rem-first sizing
+
+Per AGENTS.md, the only legitimate `px` are:
+
+- `1px` hairline borders.
+- Box-shadow offsets.
+- JS-internal pixels in `IntersectionObserver` rootMargin.
+- Sub-pixel decoration values inside SVG data URIs.
+
+CodeRabbit flagged `1.2px` / `1px` on the mobile-menu hamburger
+bars; both got converted to rem. Scan the diff for any other px
+values that aren't on the allowed list.
+
+### 5. Inline `style=""` attributes
+
+None allowed in `.astro` markup except for dynamic CSS custom
+properties. Search the diff for `style="`. Each hit gets moved to a
+scoped `<style>` block under a class name.
+
+### 6. CodeRabbit-specific anti-patterns
+
+- **`<aside>` for in-page navigation lists.** `<aside>` is a
+  *complementary* landmark; in-page jump nav should be `<nav>`. The
+  `/experience` timeline got flagged for this.
+- **`@media (max-width: var(--bp))`.** No browser supports CSS
+  custom properties inside `@media` conditions. Don't ship this.
+- **Tablet breakpoint added without strong reason.** This repo uses
+  a single mobile breakpoint at `45rem`. Any new
+  `@media (min-width: …rem)` outside that one needs justification.
+
+### 7. PR workflow checks
+
+- Branch name follows `<kind>/<short-slug>` (e.g., `fix/responsive`,
+  `feat/404-page-variant-a`, `chore/repo-hygiene`).
+- Commit subjects are imperative (`fix: …`, `feat: …`, `refine: …`).
+- No `--amend` on commits already pushed to origin — this repo
+  squash-merges, so adding a new commit is the right move.
+- `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>` trailer
+  present on agent-authored commits.
+
+### 8. Build & type gates
+
+If the diff touches `src/`:
+
+```bash
+yarn check:astro      # type / diagnostic
+yarn build            # production build, surfaces MDX schema errors
+```
+
+Both should pass before you ship. (Use `/verify` for this — it also
+filters Biome's `noUnusedImports` false positives on `.astro` files.)
+
+### 9. CodeRabbit timing
+
+After opening the PR, **wait for CodeRabbit before merging.** Quote
+from AGENTS.md: "merging before the bot finishes logs 'Review
+failed - the pull request is closed' and wastes the review."
+
+The escape clause: "if CodeRabbit is rate-limited or stuck 'in
+progress' for many minutes, skip waiting and continue." We've used
+this on PR #57.
+
+## Output
+
+Group findings by category (Semantic HTML / a11y / Sizing / Inline
+styles / Workflow). For each one:
+
+- File:line.
+- The rule it violates.
+- Suggested fix (concrete diff).
+
+End with:
+
+- "Pre-flight verdict: ready to push / N fixes recommended first."
+- If verdict is "ready," remind the user that CodeRabbit will still
+  do its own pass and may surface things this skill doesn't know
+  about yet.
+
+## What this skill does not do
+
+- It does not push, open PRs, or merge. That's the user's call.
+- It does not run `gh pr review --approve` — the review is for
+  internal triage, not for marking the PR approved.
+- It does not replace CodeRabbit. CodeRabbit sees patterns this
+  skill hasn't learned about yet.
+
+## Updating this skill
+
+When CodeRabbit catches a *new* pattern this skill missed, add it to
+the list above so future runs catch it locally. The skill should
+get smarter with each PR it learns from.

--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: simplify
+description: Review the current changes in this Astro + vanilla-CSS portfolio (chomat.tech v2) for the specific simplifications this codebase rewards — rem-first conversions, inline-style → scoped <style> moves, dead component variants from the v2 redesign, hardcoded copy that should live in SITE, and CSS that fights the design system. Operates on changed files unless given a path.
+---
+
+# /simplify (chomat.tech v2)
+
+A project-tailored simplification pass for chomat.tech v2. The
+generic "look for reuse, quality, efficiency" framing misses the
+things this codebase actually rewards. Use these rules instead.
+
+## Scope
+
+Default scope is the changed files on the current branch:
+
+```bash
+git diff --name-only "$(git merge-base HEAD V2-redesign)..HEAD"
+```
+
+If the user passes a path, use that instead.
+
+## What to look for (in priority order)
+
+### 1. Inline styles → scoped `<style>`
+
+AGENTS.md is explicit: no `style="..."` attributes in `.astro`
+markup. The one allowed exception is a *dynamic* CSS custom
+property (e.g., `style={\`--ph-h: ${heightRem};\`}`).
+
+Find: `grep -nP '\sstyle="[^"]+"' src/components src/pages src/layouts`.
+
+For each match, move the rule into the file's scoped `<style>` block
+under a class. If the file has no `<style>` block yet, add one at
+the bottom following the existing pattern (see `Hero.astro` or any
+existing section).
+
+### 2. `px` values that should be `rem`
+
+Only legitimate `px` values (per AGENTS.md):
+
+- `1px` hairline borders / dividers (`border: 1px solid var(--line)`).
+- Box-shadow offsets.
+- JS-internal pixels in `IntersectionObserver` rootMargin.
+- Sub-pixel decoration values inside SVG data URIs.
+
+Everything else should be rem. Convert: `px / 16` → rem (e.g.,
+`1.2px` → `0.075rem`).
+
+Find: `grep -nE '[: ][0-9]+\.[0-9]+px|[: ][2-9][0-9]*px' src/styles src/components src/pages | grep -v 'box-shadow\|1px solid\|rootMargin\|inset 0 0'`.
+
+Spot-check each hit — `2px solid` borders are legitimate edge-cases
+the rule doesn't strictly cover; defer to the author. The clear wins
+are values like `12px`, `22px`, `88px` outside box-shadow/borders.
+
+### 3. Hardcoded copy that should live in `SITE`
+
+`src/data/site.ts` is the home for **all site-level prose** — hero
+copy, section headings, contact cards, footer, page-specific
+strings. Project/experience/company text lives in the relevant
+Content Collection.
+
+Find string literals in `src/components/homepage/*.astro`,
+`src/pages/*.astro` that are user-visible prose (not classnames,
+not `aria-label="…"` boilerplate). Anything ≥3 words of marketing
+or editorial copy belongs in `SITE` or in a Content Collection.
+
+### 4. `min-height` on grid cards
+
+AGENTS.md: "Don't add `min-height: …rem` to cards to enforce row
+alignment — that's grid's job." CSS Grid's default
+`align-items: stretch` keeps cards in the same row equal-height.
+
+Find: `grep -nE 'min-height:\s*[0-9]' src/styles src/components src/pages | grep -i 'card\|.*ph\b'`.
+
+Each hit is suspect. Real exceptions: `placeholder` SVGs that need a
+fixed shape (`9 / 16` aspect-ratio is preferred — see Now thumbs).
+
+### 5. Dead component variants from the v2 redesign
+
+The design canvas under `design/` shipped many variants
+(`HomepageA/B/C/D`, `MobileHomepageACompact*`, `NotFoundA/B`,
+`ExperienceExpandedA/B`). The locked-in choices are:
+
+- Homepage: variant A no-navbar (mobile) / pill nav (desktop).
+- /404: variant A sketched.
+- /experience: variant A v1 (`ExperienceExpandedA` with `ExpAboutV1`,
+  `Pro='strip'`).
+
+If you find CSS/JS in `src/` that only matches a *non-shipped*
+variant (e.g., bottom-dock mobile nav, sitemap-as-art 404), flag it
+for removal. Don't auto-delete — confirm with the user.
+
+### 6. Selectors that fight the cascade
+
+AGENTS.md enforces:
+
+- `@layer reset, base, components, utilities` order in `global.css`.
+- Each partial wraps its rules in a single `.wf { … }` parent with
+  `&` for state/child selectors.
+- Native CSS nesting only (no preprocessor).
+
+Find: rules in `src/styles/components/*.css` that:
+- Use `>` or descendant selectors instead of nested `& .child` /
+  `& > .child`.
+- Live outside the `.wf { … }` block.
+- Use bare class selectors that could be expressed as nested state
+  on a parent (e.g., `.card.active` written as a separate top-level
+  rule).
+
+### 7. CSS custom properties in `@media` query conditions
+
+Don't attempt `@media (max-width: var(--bp))`. No browser supports
+it. Hard rule from AGENTS.md.
+
+### 8. Astro-specific gotchas
+
+- `<script>` blocks in `.astro` files are deferred ES modules — they
+  run *after* the document is parsed. Find any
+  `addEventListener('DOMContentLoaded', …)` inside a `.astro`
+  `<script>` and flag it: the wrapping is dead weight.
+- `for (const item of nodeList)` — `NodeListOf<T>` doesn't implement
+  `Symbol.iterator` under Astro's TS lib config. Look for it; wrap
+  in `Array.from(…)` if you see it.
+
+## Output
+
+Group findings by file. For each one:
+
+- File:line reference.
+- One-line description of the issue.
+- Suggested fix (concrete diff fragment, not just "convert to rem").
+
+End with a short summary line: "N findings across M files; would
+you like me to apply them?" — then wait. Don't auto-apply.
+
+## What this skill does not do
+
+- It does not run `yarn build` / `yarn check:astro` — that's
+  `/verify`'s job.
+- It does not refactor for performance — this is a static site, the
+  shippable wins are clarity, not microseconds.
+- It does not propose new abstractions. "Three similar lines is
+  better than a premature abstraction" — that line is from this
+  project's instructions and applies here.

--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -90,6 +90,10 @@ If you find CSS/JS in `src/` that only matches a *non-shipped*
 variant (e.g., bottom-dock mobile nav, sitemap-as-art 404), flag it
 for removal. Don't auto-delete — confirm with the user.
 
+> Note: `design/` is gitignored, so collaborators without the
+> original canvas can't see what was rejected. Treat the list above
+> as authoritative until the design canvas is published elsewhere.
+
 ### 6. Selectors that fight the cascade
 
 AGENTS.md enforces:

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: verify
+description: Run check:astro + build + biome and report only the real errors. Use before committing or pushing a branch. Filters out Biome's noUnusedImports false positives on .astro files (template-only imports), per AGENTS.md.
+---
+
+# /verify
+
+One-shot pre-push gate for chomat.tech. Catches the things that break
+CI, but stays quiet about the false positives Biome emits for
+`.astro` template-only imports.
+
+## Steps
+
+1. **Astro type check**
+
+   ```bash
+   yarn check:astro
+   ```
+
+   Fails on missing exports, bad prop types, wrong Content Collection
+   shapes. Hard error — stop here if it fails.
+
+2. **Production build**
+
+   ```bash
+   yarn build
+   ```
+
+   Catches MDX schema mismatches, missing slugs, broken imports the
+   type checker can't see. Hard error — stop here if it fails.
+
+3. **Biome (lint + format)**
+
+   ```bash
+   npx biome check .
+   ```
+
+   Run, then filter:
+
+   - **Ignore** `lint/correctness/noUnusedImports` *only* on `.astro`
+     files — Biome can't see template-only usage of imported
+     components (per AGENTS.md).
+   - **Report** everything else (real `error` and `warning` lines).
+
+   When summarising, separate "real findings" from "skipped false
+   positives" so the user can audit the filter.
+
+## What this skill does not do
+
+- It does not auto-fix. If you want fixes, run
+  `npx biome check . --write` yourself and re-verify.
+- It does not run tests — this repo has none yet.
+- It does not push, commit, or open PRs. Use it as a gate; the user
+  decides what's next.
+
+## Output shape
+
+After running, report:
+
+- `check:astro`: pass / fail (and the diagnostic count if non-zero)
+- `yarn build`: pass / fail (and which page failed if any)
+- `biome`: real-error count, real-warning count, and the count of
+  `noUnusedImports`-on-`.astro` lines you filtered out
+
+Keep it under ~10 lines unless something failed.

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -42,6 +42,12 @@ CI, but stays quiet about the false positives Biome emits for
      components (per AGENTS.md).
    - **Report** everything else (real `error` and `warning` lines).
 
+   ⚠ The filter is by extension, not by analysis — if a `.astro`
+   file ever has a genuinely unused import (rare but possible:
+   stale dev import, refactored-out type), this skill will hide it.
+   Show the user the *filtered* count alongside the real findings
+   so they can spot-check if they want.
+
    When summarising, separate "real findings" from "skipped false
    positives" so the user can audit the filter.
 

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ pnpm-debug.log*
 
 # local design scratch (wireframes, screenshots, JSX playground)
 design/
+
+# Claude Code — keep shared skills, ignore session-local state
+.claude/settings.local.json
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## Summary
Six \`.claude/skills/\` skills, each tailored to chomat.tech v2 instead of generic advice.

| Skill | What it does |
|---|---|
| \`/verify\` | Pre-push gate: \`check:astro\` + \`build\` + biome, with the AGENTS.md filter for \`noUnusedImports\` on \`.astro\` files. |
| \`/simplify\` | Refactor pass keyed to this repo's rules: rem-first, no inline \`style=\`, hardcoded prose → \`SITE\`, no \`min-height\` on grid cards, dead variants from the v2 redesign. |
| \`/review\` | Pre-CodeRabbit local review aware of the patterns the bot has been catching here — semantic \`<nav>\` landmarks, \`aria-current\` on jump links, \`aria-label\` on mobile-collapsed text, rem-first decoration values. |
| \`/add-project\` | Scaffold an MDX project entry against the Zod schema in \`src/content/config.ts\`. |
| \`/add-experience\` | Scaffold a new experience entry or append a new interval to an existing one (the Partners Bank \"left and came back\" pattern). |
| \`/add-section\` | Scaffold a homepage section: SITE copy block + Astro component + register in \`src/pages/index.astro\`. |

Also gitignores \`.claude/settings.local.json\` and \`scheduled_tasks.lock\` so the per-user state stays local while the shared skills ship.

## Test plan
- [ ] In a new Claude Code session, typing \`/verify\` lists the skill in the available list.
- [ ] Same for \`/simplify\`, \`/review\`, \`/add-project\`, \`/add-experience\`, \`/add-section\`.
- [ ] \`git status\` no longer shows \`.claude/settings.local.json\` or \`.claude/scheduled_tasks.lock\` as untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)