### PR TITLE
fix(work,now): lift sticker above placeholder image

### DIFF
--- a/src/components/homepage/Now.astro
+++ b/src/components/homepage/Now.astro
@@ -139,6 +139,7 @@ const tints: Record<string, string> = {
         position: absolute;
         top: 1.5rem;
         right: 1.75rem;
+        z-index: 1;
     }
     .featured-title {
         margin-top: 0.375rem;
@@ -162,5 +163,6 @@ const tints: Record<string, string> = {
         position: absolute;
         top: 0.875rem;
         right: 0.875rem;
+        z-index: 1;
     }
 </style>

--- a/src/components/homepage/Work.astro
+++ b/src/components/homepage/Work.astro
@@ -87,6 +87,7 @@ const cards = (
         position: absolute;
         top: 0.875rem;
         right: 0.875rem;
+        z-index: 1;
     }
     .work-head {
         margin-top: 0.375rem;


### PR DESCRIPTION
## Summary
The Walletory \"PRE-LAUNCH\" sticker (and any other work-card / featured-card / now-small sticker over a Placeholder) was rendering behind its image at narrow mobile widths — only the rotation overflow at the top edge was visible. Same root cause for all three sticker call sites.

## Root cause
- The sticker wrapper (\`.work-sticker\`, \`.featured-sticker\`, \`.now-small-sticker\`) is \`position: absolute\` with **no z-index**.
- The Placeholder (\`.ph\`) is \`position: relative\` (it needs to be — its diagonal-line background sits on a pseudo-element).
- Both are positioned with \`z-index: auto\` in the same stacking context, so paint order is **source order**. The sticker comes *first* in markup, so the Placeholder paints on top of it.

## Fix
Set \`z-index: 1\` on each of the three sticker wrappers. Three local edits rather than a shared utility — only three call sites use this pattern today and AGENTS.md prefers \"three similar lines\" over a premature abstraction.

## Test plan
- [ ] Walletory tile on /#work at mobile widths shows the full \"PRE-LAUNCH\" sticker over the top-right corner of the placeholder, not just the rotated overflow.
- [ ] Featured Moments tile on /#now still shows its sticker (regression check on \`.featured-sticker\`).
- [ ] Now-small tiles (IGIC / Companion) still show their stickers (regression check on \`.now-small-sticker\`).
- [ ] Desktop unchanged (just a fix that becomes visible only where the sticker overlapped the image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual stacking order of stickers in the homepage "Now" section and "Work" section to ensure they display with proper layering relative to other elements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DanielChomat/chomat.tech/pull/61?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->