### PR TITLE
feat: dark mode + design-canvas alignment

### DIFF
--- a/src/components/nav/ThemeToggle.astro
+++ b/src/components/nav/ThemeToggle.astro
@@ -1,0 +1,109 @@
+---
+// Theme toggle — flips between light and dark, persists to
+// localStorage('theme'), and updates <meta name="theme-color"> so iOS
+// Safari's chrome band matches. Initial state is set before paint by
+// the inline script in BaseLayout, so this button only handles the
+// click and the post-render sync of its own aria-pressed/title.
+---
+
+<button
+    type="button"
+    class="theme-toggle"
+    aria-pressed="false"
+    aria-label="Switch to dark mode"
+    title="Light"
+    data-theme-toggle
+>
+    <span class="theme-toggle__icon theme-toggle__icon--sun" aria-hidden="true">
+        <svg
+            viewBox="0 0 24 24"
+            width="14"
+            height="14"
+            fill="none"
+            aria-hidden="true"
+            focusable="false"
+        >
+            <circle cx="12" cy="12" r="4" fill="currentcolor"></circle>
+            <g stroke="currentcolor" stroke-width="1.6" stroke-linecap="round">
+                <path d="M12 2v3"></path>
+                <path d="M12 19v3"></path>
+                <path d="M2 12h3"></path>
+                <path d="M19 12h3"></path>
+                <path d="M4.5 4.5l2.1 2.1"></path>
+                <path d="M17.4 17.4l2.1 2.1"></path>
+                <path d="M4.5 19.5l2.1-2.1"></path>
+                <path d="M17.4 6.6l2.1-2.1"></path>
+            </g>
+        </svg>
+    </span>
+    <span class="theme-toggle__icon theme-toggle__icon--moon" aria-hidden="true">
+        <svg
+            viewBox="0 0 24 24"
+            width="14"
+            height="14"
+            fill="none"
+            aria-hidden="true"
+            focusable="false"
+        >
+            <path
+                d="M20 14.5A8 8 0 1 1 9.5 4a6.5 6.5 0 0 0 10.5 10.5z"
+                fill="currentcolor"
+            ></path>
+        </svg>
+    </span>
+</button>
+
+<script>
+    const root = document.documentElement;
+    const button = document.querySelector<HTMLButtonElement>(
+        "[data-theme-toggle]"
+    );
+    if (!button) {
+        // Nothing more to do — the inline pre-paint script in BaseLayout
+        // already established the theme.
+    } else {
+        const themeColors = { light: "#f8f5ec", dark: "#0e0d0a" } as const;
+
+        const sync = (theme: "light" | "dark") => {
+            const isDark = theme === "dark";
+            button.setAttribute("aria-pressed", isDark ? "true" : "false");
+            button.setAttribute(
+                "aria-label",
+                isDark ? "Switch to light mode" : "Switch to dark mode"
+            );
+            button.setAttribute("title", isDark ? "Dark" : "Light");
+            const meta = document.querySelector<HTMLMetaElement>(
+                'meta[name="theme-color"]'
+            );
+            if (meta) meta.setAttribute("content", themeColors[theme]);
+        };
+
+        const current = (root.dataset.theme === "dark" ? "dark" : "light");
+        sync(current);
+
+        button.addEventListener("click", () => {
+            const next = root.dataset.theme === "dark" ? "light" : "dark";
+            root.dataset.theme = next;
+            try {
+                localStorage.setItem("theme", next);
+            } catch {
+                /* storage disabled — fall through */
+            }
+            sync(next);
+        });
+
+        // Track OS preference changes while no explicit choice is stored.
+        const mq = window.matchMedia("(prefers-color-scheme: dark)");
+        const onChange = (event: MediaQueryListEvent) => {
+            try {
+                if (localStorage.getItem("theme")) return;
+            } catch {
+                /* storage disabled — still follow the OS */
+            }
+            const next = event.matches ? "dark" : "light";
+            root.dataset.theme = next;
+            sync(next);
+        };
+        mq.addEventListener("change", onChange);
+    }
+</script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,4 +1,6 @@
 ---
+import SoundToggle from "../components/nav/SoundToggle.astro";
+import ThemeToggle from "../components/nav/ThemeToggle.astro";
 import { SITE } from "../data/site.ts";
 import "../styles/global.css";
 
@@ -51,6 +53,10 @@ const { title = SITE.meta.title, description = SITE.meta.description } = Astro.p
         </script>
     </head>
     <body>
-        <slot />
+        <div class="wf v3 pal-newsprint">
+            <ThemeToggle />
+            <SoundToggle />
+            <slot />
+        </div>
     </body>
 </html>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -17,10 +17,38 @@ const { title = SITE.meta.title, description = SITE.meta.description } = Astro.p
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
         <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
         <meta name="theme-color" content="#f8f5ec" />
-        <meta name="color-scheme" content="light" />
+        <meta name="color-scheme" content="light dark" />
         <meta name="generator" content={Astro.generator} />
         <meta name="description" content={description} />
         <title>{title}</title>
+        <script is:inline>
+            // Resolve theme before paint to avoid a light→dark flash.
+            // Order: stored choice → OS preference → light fallback.
+            // Mirrors the writes in ThemeToggle.astro.
+            (function () {
+                try {
+                    var stored = localStorage.getItem("theme");
+                    var prefersDark =
+                        window.matchMedia &&
+                        window.matchMedia("(prefers-color-scheme: dark)").matches;
+                    var theme =
+                        stored === "dark" || stored === "light"
+                            ? stored
+                            : prefersDark
+                              ? "dark"
+                              : "light";
+                    document.documentElement.dataset.theme = theme;
+                    var meta = document.querySelector('meta[name="theme-color"]');
+                    if (meta)
+                        meta.setAttribute(
+                            "content",
+                            theme === "dark" ? "#0e0d0a" : "#f8f5ec"
+                        );
+                } catch (err) {
+                    document.documentElement.dataset.theme = "light";
+                }
+            })();
+        </script>
     </head>
     <body>
         <slot />

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,8 +1,6 @@
 ---
 import MobileMenu from "../components/nav/MobileMenu.astro";
 import NavCapsule from "../components/nav/NavCapsule.astro";
-import SoundToggle from "../components/nav/SoundToggle.astro";
-import ThemeToggle from "../components/nav/ThemeToggle.astro";
 import Kicker from "../components/primitives/Kicker.astro";
 import { SITE } from "../data/site.ts";
 import BaseLayout from "../layouts/BaseLayout.astro";
@@ -14,13 +12,10 @@ const { notFound } = SITE;
     title="404 — Daniel Chomat"
     description="This URL doesn't resolve to anything I've built — yet."
 >
-    <div class="wf v3 pal-newsprint">
-        <ThemeToggle />
-        <SoundToggle />
-        <NavCapsule items={notFound.nav} />
-        <MobileMenu items={notFound.nav} />
-        <div class="page">
-            <main class="page-body not-found">
+    <NavCapsule items={notFound.nav} />
+    <MobileMenu items={notFound.nav} />
+    <div class="page">
+        <main class="page-body not-found">
                 <div class="nf-glyph" aria-hidden="true">
                     <span class="nf-glyph-digit">
                         4
@@ -60,8 +55,7 @@ const { notFound } = SITE;
                         >{notFound.footnoteLink}</a
                     >{notFound.footnoteTrail}
                 </p>
-            </main>
-        </div>
+        </main>
     </div>
 </BaseLayout>
 

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -2,6 +2,7 @@
 import MobileMenu from "../components/nav/MobileMenu.astro";
 import NavCapsule from "../components/nav/NavCapsule.astro";
 import SoundToggle from "../components/nav/SoundToggle.astro";
+import ThemeToggle from "../components/nav/ThemeToggle.astro";
 import Kicker from "../components/primitives/Kicker.astro";
 import { SITE } from "../data/site.ts";
 import BaseLayout from "../layouts/BaseLayout.astro";
@@ -14,6 +15,7 @@ const { notFound } = SITE;
     description="This URL doesn't resolve to anything I've built — yet."
 >
     <div class="wf v3 pal-newsprint">
+        <ThemeToggle />
         <SoundToggle />
         <NavCapsule items={notFound.nav} />
         <MobileMenu items={notFound.nav} />

--- a/src/pages/experience.astro
+++ b/src/pages/experience.astro
@@ -3,8 +3,6 @@ import { getCollection, render } from "astro:content";
 import SiteFooter from "../components/homepage/SiteFooter.astro";
 import MobileMenu from "../components/nav/MobileMenu.astro";
 import NavCapsule from "../components/nav/NavCapsule.astro";
-import SoundToggle from "../components/nav/SoundToggle.astro";
-import ThemeToggle from "../components/nav/ThemeToggle.astro";
 import Kicker from "../components/primitives/Kicker.astro";
 import Pill from "../components/primitives/Pill.astro";
 import StatusPill from "../components/primitives/StatusPill.astro";
@@ -14,9 +12,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 
 const copy = SITE.experiencePage;
 
-const entries = (await getCollection("experience")).sort(
-    (a, b) => a.data.order - b.data.order
-);
+const entries = (await getCollection("experience")).sort((a, b) => a.data.order - b.data.order);
 
 const rendered = await Promise.all(
     entries.map(async (entry) => {
@@ -36,13 +32,10 @@ const rendered = await Promise.all(
     title="Experience — Daniel Chomat"
     description="Six years across one agency, one bank (twice), and one freelance umbrella in between. The long version."
 >
-    <div class="wf v3 pal-newsprint">
-        <ThemeToggle />
-        <SoundToggle />
-        <NavCapsule items={copy.nav} active={copy.navActiveIndex} />
-        <MobileMenu items={copy.nav} active={copy.navActiveIndex} />
-        <div class="page">
-            <main id="top" class="page-body experience-page">
+    <NavCapsule items={copy.nav} active={copy.navActiveIndex} />
+    <MobileMenu items={copy.nav} active={copy.navActiveIndex} />
+    <div class="page">
+        <main id="top" class="page-body experience-page">
                 <nav class="exp-crumbs" aria-label="Breadcrumb">
                     <a
                         class="t-mono muted exp-crumb-home"
@@ -204,9 +197,8 @@ const rendered = await Promise.all(
                         }
                     </ol>
                 </section>
-                <SiteFooter backToTopHref="#top" />
-            </main>
-        </div>
+        <SiteFooter backToTopHref="#top" />
+        </main>
     </div>
 </BaseLayout>
 

--- a/src/pages/experience.astro
+++ b/src/pages/experience.astro
@@ -4,6 +4,7 @@ import SiteFooter from "../components/homepage/SiteFooter.astro";
 import MobileMenu from "../components/nav/MobileMenu.astro";
 import NavCapsule from "../components/nav/NavCapsule.astro";
 import SoundToggle from "../components/nav/SoundToggle.astro";
+import ThemeToggle from "../components/nav/ThemeToggle.astro";
 import Kicker from "../components/primitives/Kicker.astro";
 import Pill from "../components/primitives/Pill.astro";
 import StatusPill from "../components/primitives/StatusPill.astro";
@@ -36,6 +37,7 @@ const rendered = await Promise.all(
     description="Six years across one agency, one bank (twice), and one freelance umbrella in between. The long version."
 >
     <div class="wf v3 pal-newsprint">
+        <ThemeToggle />
         <SoundToggle />
         <NavCapsule items={copy.nav} active={copy.navActiveIndex} />
         <MobileMenu items={copy.nav} active={copy.navActiveIndex} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,12 +10,14 @@ import Work from "../components/homepage/Work.astro";
 import MobileMenu from "../components/nav/MobileMenu.astro";
 import NavCapsule from "../components/nav/NavCapsule.astro";
 import SoundToggle from "../components/nav/SoundToggle.astro";
+import ThemeToggle from "../components/nav/ThemeToggle.astro";
 import { SITE } from "../data/site.ts";
 import BaseLayout from "../layouts/BaseLayout.astro";
 ---
 
 <BaseLayout>
     <div class="wf v3 pal-newsprint">
+        <ThemeToggle />
         <SoundToggle />
         <NavCapsule items={SITE.nav} />
         <MobileMenu items={SITE.nav} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,31 +9,25 @@ import Tech from "../components/homepage/Tech.astro";
 import Work from "../components/homepage/Work.astro";
 import MobileMenu from "../components/nav/MobileMenu.astro";
 import NavCapsule from "../components/nav/NavCapsule.astro";
-import SoundToggle from "../components/nav/SoundToggle.astro";
-import ThemeToggle from "../components/nav/ThemeToggle.astro";
 import { SITE } from "../data/site.ts";
 import BaseLayout from "../layouts/BaseLayout.astro";
 ---
 
 <BaseLayout>
-    <div class="wf v3 pal-newsprint">
-        <ThemeToggle />
-        <SoundToggle />
-        <NavCapsule items={SITE.nav} />
-        <MobileMenu items={SITE.nav} />
-        <div class="page">
-            <main class="page-body">
-                <div class="section-stack">
-                    <Hero />
-                    <Now />
-                    <Experience />
-                    <Work />
-                    <Tech />
-                    <Companies />
-                    <Contact />
-                </div>
-                <SiteFooter />
-            </main>
-        </div>
+    <NavCapsule items={SITE.nav} />
+    <MobileMenu items={SITE.nav} />
+    <div class="page">
+        <main class="page-body">
+            <div class="section-stack">
+                <Hero />
+                <Now />
+                <Experience />
+                <Work />
+                <Tech />
+                <Companies />
+                <Contact />
+            </div>
+            <SiteFooter />
+        </main>
     </div>
 </BaseLayout>

--- a/src/styles/components/card.css
+++ b/src/styles/components/card.css
@@ -58,6 +58,18 @@
             }
         }
 
+        /* Dark mode: in light, `.inked` swaps fg/bg to print white-on-black.
+           In dark that double-inverts back to near-invisible, so use a
+           lifted surface that contrasts gently with the page bg instead. */
+        html[data-theme="dark"] & .card.inked {
+            background: var(--surface-2);
+            color: var(--text);
+            border-color: var(--line);
+
+            & .t-mono { color: var(--muted); }
+            & .muted  { color: var(--muted); }
+        }
+
         & .card-head {
             display: flex;
             align-items: baseline;

--- a/src/styles/components/controls.css
+++ b/src/styles/components/controls.css
@@ -125,12 +125,11 @@
             overflow: hidden;
             height: var(--ph-h, 7.5rem);
         }
-    }
 
-    /* Dark: hide the sun, reveal the moon. Selector parents the .wf so
-       the toggle remains scoped to the design-system root. */
-    html[data-theme="dark"] .wf {
-        & .theme-toggle .theme-toggle__icon--sun  { display: none; }
-        & .theme-toggle .theme-toggle__icon--moon { display: inline-flex; }
+        /* Dark: hide the sun, reveal the moon. */
+        html[data-theme="dark"] & {
+            & .theme-toggle .theme-toggle__icon--sun  { display: none; }
+            & .theme-toggle .theme-toggle__icon--moon { display: inline-flex; }
+        }
     }
 }

--- a/src/styles/components/controls.css
+++ b/src/styles/components/controls.css
@@ -58,6 +58,55 @@
             }
         }
 
+        /* Theme toggle — same chip styling as sound-toggle, parked to its
+           left so the two form a small cluster bottom-right. The right
+           offset (sound-toggle width + gap) keeps them paired across
+           breakpoints. */
+        & .theme-toggle {
+            position: fixed;
+            right: calc(1.375rem + 2.75rem + 0.5rem);
+            bottom: calc(1.375rem + env(safe-area-inset-bottom, 0px));
+            z-index: 6;
+            width: 2.75rem;
+            height: 2.75rem;
+            padding: 0;
+            appearance: none;
+            cursor: pointer;
+            border-radius: 50%;
+            border: 1px solid var(--line);
+            background: var(--surface);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: var(--muted);
+            box-shadow: var(--shadow);
+            transition: color 150ms ease, background 150ms ease;
+
+            & .theme-toggle__icon {
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                line-height: 0;
+            }
+            & .theme-toggle__icon--moon { display: none; }
+
+            &:hover,
+            &:focus-visible {
+                color: var(--text);
+            }
+
+            @media (max-width: 45rem) {
+                width: 2.5rem;
+                height: 2.5rem;
+                right: calc(1rem + 2.5rem + 0.5rem);
+                bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
+            }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            & .theme-toggle { transition: none; }
+        }
+
         & .ph {
             background:
                 repeating-linear-gradient(135deg, var(--line-2) 0 1px, transparent 1px 0.5625rem),
@@ -76,5 +125,12 @@
             overflow: hidden;
             height: var(--ph-h, 7.5rem);
         }
+    }
+
+    /* Dark: hide the sun, reveal the moon. Selector parents the .wf so
+       the toggle remains scoped to the design-system root. */
+    html[data-theme="dark"] .wf {
+        & .theme-toggle .theme-toggle__icon--sun  { display: none; }
+        & .theme-toggle .theme-toggle__icon--moon { display: inline-flex; }
     }
 }

--- a/src/styles/components/decorations.css
+++ b/src/styles/components/decorations.css
@@ -92,31 +92,31 @@
                 z-index: 5;
             }
         }
-    }
 
-    /* Dark mode: marker highlights look opaque-yellow on dark — replace
-       with subtle tinted washes that read on the dark bg. Grain blend
-       flips from multiply (dark-on-light) to screen (light-on-dark). */
-    html[data-theme="dark"] .wf {
-        & .marker {
-            background: linear-gradient(
-                180deg,
-                transparent 50%,
-                color-mix(in oklab, var(--tint-butter) 70%, transparent) 50%
-            );
-            color: var(--text);
-        }
-        & .marker-sage {
-            background: linear-gradient(
-                180deg,
-                transparent 50%,
-                color-mix(in oklab, var(--tint-sage) 70%, transparent) 50%
-            );
-            color: var(--text);
-        }
-        &.v3::after {
-            mix-blend-mode: screen;
-            opacity: 0.08;
+        /* Dark: marker highlights would read as opaque-yellow on dark, so
+           switch to subtle tinted washes; the v3 grain blend flips from
+           multiply (dark-on-light) to screen (light-on-dark). */
+        html[data-theme="dark"] & {
+            & .marker {
+                background: linear-gradient(
+                    180deg,
+                    transparent 50%,
+                    color-mix(in oklab, var(--tint-butter) 70%, transparent) 50%
+                );
+                color: var(--text);
+            }
+            & .marker-sage {
+                background: linear-gradient(
+                    180deg,
+                    transparent 50%,
+                    color-mix(in oklab, var(--tint-sage) 70%, transparent) 50%
+                );
+                color: var(--text);
+            }
+            &.v3::after {
+                mix-blend-mode: screen;
+                opacity: 0.08;
+            }
         }
     }
 }

--- a/src/styles/components/decorations.css
+++ b/src/styles/components/decorations.css
@@ -93,4 +93,30 @@
             }
         }
     }
+
+    /* Dark mode: marker highlights look opaque-yellow on dark — replace
+       with subtle tinted washes that read on the dark bg. Grain blend
+       flips from multiply (dark-on-light) to screen (light-on-dark). */
+    html[data-theme="dark"] .wf {
+        & .marker {
+            background: linear-gradient(
+                180deg,
+                transparent 50%,
+                color-mix(in oklab, var(--tint-butter) 70%, transparent) 50%
+            );
+            color: var(--text);
+        }
+        & .marker-sage {
+            background: linear-gradient(
+                180deg,
+                transparent 50%,
+                color-mix(in oklab, var(--tint-sage) 70%, transparent) 50%
+            );
+            color: var(--text);
+        }
+        &.v3::after {
+            mix-blend-mode: screen;
+            opacity: 0.08;
+        }
+    }
 }

--- a/src/styles/components/pill.css
+++ b/src/styles/components/pill.css
@@ -70,4 +70,11 @@
         70%  { box-shadow: 0 0 0 0.625rem transparent; }
         100% { box-shadow: 0 0 0 0 transparent; }
     }
+
+    /* Dark mode: the sticker's box-shadow is `var(--text)` (a near-black
+       smudge), which disappears against the dark bg. Swap to a light
+       wash so the offset shadow stays visible. */
+    html[data-theme="dark"] .wf .sticker {
+        box-shadow: 2px 2px 0 rgba(255, 250, 235, 0.5);
+    }
 }

--- a/src/styles/components/pill.css
+++ b/src/styles/components/pill.css
@@ -63,18 +63,18 @@
             &.s-sky    { background: var(--tint-sky);    color: var(--text); }
             &.s-lav    { background: var(--tint-lavender); color: var(--text); }
         }
+
+        /* Dark: the sticker's box-shadow is var(--text) — a near-black
+           smudge that disappears against the dark bg. Swap to a light
+           wash so the offset shadow stays visible. */
+        html[data-theme="dark"] & .sticker {
+            box-shadow: 2px 2px 0 rgba(255, 250, 235, 0.5);
+        }
     }
 
     @keyframes wf-pulse {
         0%   { box-shadow: 0 0 0 0 color-mix(in oklab, var(--accent) 60%, transparent); }
         70%  { box-shadow: 0 0 0 0.625rem transparent; }
         100% { box-shadow: 0 0 0 0 transparent; }
-    }
-
-    /* Dark mode: the sticker's box-shadow is `var(--text)` (a near-black
-       smudge), which disappears against the dark bg. Swap to a light
-       wash so the offset shadow stays visible. */
-    html[data-theme="dark"] .wf .sticker {
-        box-shadow: 2px 2px 0 rgba(255, 250, 235, 0.5);
     }
 }

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -19,6 +19,15 @@
         color: #16140f;
     }
 
+    /* Pre-token paint colors for dark mode — applied before .wf tokens
+       resolve so the page never flashes light. The inline theme script
+       in BaseLayout sets [data-theme] before first paint. */
+    html[data-theme="dark"],
+    html[data-theme="dark"] body {
+        background: #0e0d0a;
+        color: #ece8de;
+    }
+
     @media (prefers-reduced-motion: no-preference) {
         html {
             scroll-behavior: smooth;

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,5 +1,11 @@
 /* Design tokens — .wf root + active palette + v3 font features.
-   Loaded into @layer base. */
+   Loaded into @layer base.
+
+   Dark mode: gated by [data-theme="dark"] on <html>. A blocking inline
+   script in BaseLayout sets that attribute before paint based on
+   localStorage('theme') ?? prefers-color-scheme. The dark token block
+   re-declares the same custom properties (incl. tints) so it wins over
+   any active .pal-* palette modifier. */
 
 @layer base {
     .wf {
@@ -50,5 +56,31 @@
                 "ss02" on,
                 "cv11" on;
         }
+    }
+
+    /* Dark mode — declared after the light palettes so it wins the cascade.
+       Selector wraps everything: any palette modifier on .wf is overridden
+       once html[data-theme="dark"] is present. Tints are deepened versions
+       that still read warm. */
+    html[data-theme="dark"] .wf,
+    html[data-theme="dark"] .wf.pal-newsprint {
+        --bg: #0e0d0a;
+        --surface: #15140f;
+        --surface-2: #1a1914;
+        --text: #ece8de;
+        --muted: #8e8a80;
+        --faint: #4d4942;
+        --line: rgba(255, 250, 235, 0.1);
+        --line-2: rgba(255, 250, 235, 0.05);
+        --accent: #2cada3;
+        --accent-ink: #0e0d0a;
+        --shadow:
+            0 1px 0 rgba(0, 0, 0, 0.3),
+            0 12px 28px -16px rgba(0, 0, 0, 0.6);
+        --tint-butter: #4a3e1a;
+        --tint-sage: #2a3a25;
+        --tint-rose: #482620;
+        --tint-sky: #1f2e3e;
+        --tint-lavender: #2c2640;
     }
 }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -56,31 +56,32 @@
                 "ss02" on,
                 "cv11" on;
         }
-    }
 
-    /* Dark mode — declared after the light palettes so it wins the cascade.
-       Selector wraps everything: any palette modifier on .wf is overridden
-       once html[data-theme="dark"] is present. Tints are deepened versions
-       that still read warm. */
-    html[data-theme="dark"] .wf,
-    html[data-theme="dark"] .wf.pal-newsprint {
-        --bg: #0e0d0a;
-        --surface: #15140f;
-        --surface-2: #1a1914;
-        --text: #ece8de;
-        --muted: #8e8a80;
-        --faint: #4d4942;
-        --line: rgba(255, 250, 235, 0.1);
-        --line-2: rgba(255, 250, 235, 0.05);
-        --accent: #2cada3;
-        --accent-ink: #0e0d0a;
-        --shadow:
-            0 1px 0 rgba(0, 0, 0, 0.3),
-            0 12px 28px -16px rgba(0, 0, 0, 0.6);
-        --tint-butter: #4a3e1a;
-        --tint-sage: #2a3a25;
-        --tint-rose: #482620;
-        --tint-sky: #1f2e3e;
-        --tint-lavender: #2c2640;
+        /* Dark mode — nested so the dark block + any .pal-* palette
+           modifier are overridden by the same parent. `&,&.pal-newsprint`
+           covers both the bare .wf and the newsprint palette currently
+           applied site-wide. Tints are deepened versions that still read
+           warm. */
+        html[data-theme="dark"] &,
+        html[data-theme="dark"] &.pal-newsprint {
+            --bg: #0e0d0a;
+            --surface: #15140f;
+            --surface-2: #1a1914;
+            --text: #ece8de;
+            --muted: #8e8a80;
+            --faint: #4d4942;
+            --line: rgba(255, 250, 235, 0.1);
+            --line-2: rgba(255, 250, 235, 0.05);
+            --accent: #2cada3;
+            --accent-ink: #0e0d0a;
+            --shadow:
+                0 1px 0 rgba(0, 0, 0, 0.3),
+                0 12px 28px -16px rgba(0, 0, 0, 0.6);
+            --tint-butter: #4a3e1a;
+            --tint-sage: #2a3a25;
+            --tint-rose: #482620;
+            --tint-sky: #1f2e3e;
+            --tint-lavender: #2c2640;
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Add the dark variant from `/design/styles.css` to the live design system. Wireframes ship a `.wf.dark` token block; the live site was light-only.
- New `ThemeToggle.astro` button pairs with `SoundToggle` bottom-right; persists to `localStorage('theme')`, honours `prefers-color-scheme`, no-flash via a blocking inline script in `BaseLayout`.
- Dark-specific overrides land alongside the rules they parent: sticker shadow flips to a light wash, marker highlights become subtle tinted washes, inked card falls back to a lifted surface (the light variant's fg/bg swap would double-invert), v3 grain blend mode flips multiply → screen.
- `<meta name="theme-color">` updates dynamically so iOS Safari's chrome band matches the active theme; `color-scheme` widens to `light dark` for native form controls.

## Test plan
- [ ] Open `/` in light, scroll all sections — verify the page matches the V5 wireframe.
- [ ] Click the sun chip bottom-right — page flips to dark; sun → moon; iOS Safari chrome band swaps.
- [ ] Reload — dark persists.
- [ ] `prefers-color-scheme: dark` system preference with no stored choice — initial paint is dark.
- [ ] `/experience`, `/404` — toggle works the same; inked Resume card stays legible in dark.
- [ ] `prefers-reduced-motion: reduce` — theme-toggle transition disabled; no other regressions.
- [ ] Keyboard: tab to the toggle, Space/Enter flips theme; `aria-pressed` and `aria-label` update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a theme toggle control allowing users to switch between light and dark modes.
  * App now respects the system's preferred color scheme on first visit.
  * Theme preference is saved and persists across sessions.

* **Style**
  * Updated all components and typography with optimized dark theme colors for improved contrast and readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DanielChomat/chomat.tech/pull/63?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->