### PR TITLE
fix(experience): horizontal chip strip for mobile jumpnav

### DIFF
--- a/src/pages/experience.astro
+++ b/src/pages/experience.astro
@@ -386,6 +386,45 @@ const rendered = await Promise.all(
         .exp-jumpnav {
             position: static;
         }
+        /* Mobile: the design canvas reframes "Jump to" as a horizontal
+           chip strip (wf-mobile-experience.jsx → MobileJumpChips). Drop
+           the card chrome, scrap the vertical list, render each link
+           as a pill-shaped chip that wraps. */
+        .exp-jumpnav-card {
+            background: transparent;
+            border: 0;
+            box-shadow: none;
+            padding: 0;
+        }
+        .exp-jumpnav-list {
+            flex-direction: row;
+            flex-wrap: wrap;
+            gap: 0.375rem;
+            margin-top: 0.5rem;
+        }
+        .exp-jumpnav-link {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.375rem;
+            padding: 0.375rem 0.625rem;
+            border: 1px solid var(--line);
+            border-radius: 9999rem;
+            background: transparent;
+            font-family: var(--font-mono);
+            font-size: 0.625rem;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            color: var(--muted);
+        }
+        .exp-jumpnav-link.current {
+            background: var(--surface);
+            color: var(--text);
+        }
+        .exp-jumpnav-link .t-mono {
+            font-size: inherit;
+            letter-spacing: inherit;
+            color: inherit;
+        }
         .exp-entry-head {
             flex-direction: column;
             gap: 0.625rem;


### PR DESCRIPTION
## Summary

- Mobile-only restyle of the `/experience` "Jump to" navigation.
- Was: desktop card with vertical link list, rendered as-is on phones with `.exp-jumpnav { position: static }`. Looked like a floating nav block above the timeline.
- Now: matches `wf-mobile-experience.jsx → MobileJumpChips` — transparent container, horizontal wrap-able chip strip, each chip pill-shaped.
- Desktop sticky-sidebar behaviour is untouched.

## Test plan
- [ ] `/experience` at desktop (≥45rem): sticky aside renders unchanged.
- [ ] `/experience` at mobile (<45rem): "Jump to" appears as a chip strip; current chapter chip is filled with `var(--surface)` and the status dot pulses.
- [ ] Tapping a chip scrolls to the matching timeline card.
- [ ] Dark mode: chips still readable; current chip's surface bg lifts correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)