### PR TITLE
fix(homepage): match V4bHero + V3Companies sizing from design canvas

### DIFF
--- a/src/components/homepage/Companies.astro
+++ b/src/components/homepage/Companies.astro
@@ -25,4 +25,12 @@ const companies = (await getCollection("companies")).sort(
     .companies-card {
         padding: 1.25rem 1.75rem;
     }
+    /* V3Companies overrides the base `.logo` per-instance to a taller,
+       slightly larger label (28px / 11px vs the partial's 22px / 10px).
+       Scope the bump here so the partial defaults stay correct for any
+       future logo-strip usage. */
+    .companies-card :global(.logo-strip .logo) {
+        height: 1.75rem;
+        font-size: 0.6875rem;
+    }
 </style>

--- a/src/components/homepage/Hero.astro
+++ b/src/components/homepage/Hero.astro
@@ -38,6 +38,11 @@ const { hero } = SITE;
 </section>
 
 <style>
+    /* Per V4bHero in the design canvas — `style={{ fontSize: 160 }}` —
+       the homepage name renders larger than the v3 default. */
+    .t-mega {
+        --t-mega-max: 10rem;
+    }
     .hero-bio {
         max-width: 47.5rem;
         font-size: 1.125rem;

--- a/src/styles/type.css
+++ b/src/styles/type.css
@@ -55,8 +55,12 @@
             & .t-mega {
                 /* Floor lowered to 2rem so "Daniel Chomat*" fits the hero on
                    ~320px-wide phones (Geist medium needs ~3rem of real estate
-                   per char × 13 chars; the 14vw curve takes over above 230px). */
-                font-size: clamp(2rem, 14vw, 8.25rem);
+                   per char × 13 chars; the 14vw curve takes over above 230px).
+                   Max is parameterised via --t-mega-max so individual pages can
+                   bump the cap without rewriting the clamp — V4bHero sets 10rem
+                   (160px) on the homepage, the v3 default of 8.25rem (132px)
+                   stays put for /experience and /404. */
+                font-size: clamp(2rem, 14vw, var(--t-mega-max, 8.25rem));
                 line-height: 0.86;
                 letter-spacing: -0.045em;
                 font-weight: 500;


### PR DESCRIPTION
## Summary

Closer pass over `/design/wf-*.jsx` surfaced two spacing drifts on the homepage. Both are per-instance inline overrides in the design that weren't translated to the live partials.

- **Hero name (`.t-mega`)**: V4bHero sets `style={{ fontSize: 160 }}` — the live site was using the v3 partial default of 132px. Bumped via a parameterised `--t-mega-max` so other pages keep their cap (e.g. `/experience` "Six years.*").
- **Companies logos**: V3Companies bumps each `.logo` to 28px/11px from the partial's 22px/10px base. Scoped the override inside `.companies-card`.

## Test plan
- [ ] Homepage at ≥1080px: "Daniel Chomat*" now caps at 10rem (160px), not 8.25rem (132px).
- [ ] Homepage on phones: the clamp floor (2rem) still wins; nothing reflows.
- [ ] `/experience` h1: unchanged.
- [ ] Companies strip on desktop + mobile: logos read at 28px tall with 11px labels.
- [ ] Dark mode: both visual changes carry through token-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated logo sizing in the companies section with specific height and font-size styling.
  * Enhanced typography sizing flexibility for large text elements using configurable CSS variables.

* **Refactor**
  * Converted fixed typography sizing constraints to use CSS variables for improved maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DanielChomat/chomat.tech/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->