### PR TITLE
feat(seo,a11y): canonical, OG/Twitter meta, JSON-LD Person, skip link

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Disallow:
+
+Sitemap: https://chomat.tech/sitemap-index.xml

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,0 @@
-User-agent: *
-Disallow:
-
-Sitemap: https://chomat.tech/sitemap-index.xml

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -7,9 +7,29 @@ import "../styles/global.css";
 type Props = {
     title?: string;
     description?: string;
+    ogType?: "website" | "article" | "profile";
 };
 
-const { title = SITE.meta.title, description = SITE.meta.description } = Astro.props;
+const {
+    title = SITE.meta.title,
+    description = SITE.meta.description,
+    ogType = "website",
+} = Astro.props;
+
+const canonicalUrl = new URL(Astro.url.pathname, Astro.site).toString();
+const ogImageUrl = new URL("/og.png", Astro.site).toString();
+
+const personSchema = {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: "Daniel Chomat",
+    url: Astro.site?.toString(),
+    jobTitle: "Mobile & front-end engineer",
+    sameAs: [
+        "https://github.com/DanielChomat",
+        "https://linkedin.com/in/danielchomat",
+    ],
+};
 ---
 
 <!doctype html>
@@ -22,7 +42,27 @@ const { title = SITE.meta.title, description = SITE.meta.description } = Astro.p
         <meta name="color-scheme" content="light dark" />
         <meta name="generator" content={Astro.generator} />
         <meta name="description" content={description} />
+        <link rel="canonical" href={canonicalUrl} />
+
+        <meta property="og:type" content={ogType} />
+        <meta property="og:title" content={title} />
+        <meta property="og:description" content={description} />
+        <meta property="og:url" content={canonicalUrl} />
+        <meta property="og:site_name" content="chomat.tech" />
+        <meta property="og:locale" content="en_US" />
+        <meta property="og:image" content={ogImageUrl} />
+
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={title} />
+        <meta name="twitter:description" content={description} />
+        <meta name="twitter:image" content={ogImageUrl} />
+
         <title>{title}</title>
+        <script
+            is:inline
+            type="application/ld+json"
+            set:html={JSON.stringify(personSchema)}
+        />
         <script is:inline>
             // Resolve theme before paint to avoid a light→dark flash.
             // Order: stored choice → OS preference → light fallback.
@@ -54,9 +94,40 @@ const { title = SITE.meta.title, description = SITE.meta.description } = Astro.p
     </head>
     <body>
         <div class="wf v3 pal-newsprint">
+            <a class="skip-link" href="#main">Skip to content</a>
             <ThemeToggle />
             <SoundToggle />
             <slot />
         </div>
     </body>
 </html>
+
+<style>
+    .skip-link {
+        position: absolute;
+        top: 0.5rem;
+        left: 0.5rem;
+        z-index: 1000;
+        padding: 0.5rem 0.75rem;
+        background: var(--text);
+        color: var(--bg);
+        text-decoration: none;
+        border-radius: var(--radius-sm);
+        font-family: var(--font-sans);
+        font-size: 0.875rem;
+        font-weight: 500;
+        line-height: 1.2;
+        transform: translateY(-200%);
+        transition: transform 180ms ease;
+    }
+    .skip-link:focus-visible {
+        transform: translateY(0);
+        outline: 0.125rem solid var(--accent);
+        outline-offset: 0.125rem;
+    }
+    @media (prefers-reduced-motion: reduce) {
+        .skip-link {
+            transition: none;
+        }
+    }
+</style>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -15,7 +15,7 @@ const { notFound } = SITE;
     <NavCapsule items={notFound.nav} />
     <MobileMenu items={notFound.nav} />
     <div class="page">
-        <main class="page-body not-found">
+        <main id="main" class="page-body not-found">
                 <div class="nf-glyph" aria-hidden="true">
                     <span class="nf-glyph-digit">
                         4

--- a/src/pages/experience.astro
+++ b/src/pages/experience.astro
@@ -35,7 +35,7 @@ const rendered = await Promise.all(
     <NavCapsule items={copy.nav} active={copy.navActiveIndex} />
     <MobileMenu items={copy.nav} active={copy.navActiveIndex} />
     <div class="page">
-        <main id="top" class="page-body experience-page">
+        <main id="main" class="page-body experience-page">
                 <nav class="exp-crumbs" aria-label="Breadcrumb">
                     <a
                         class="t-mono muted exp-crumb-home"
@@ -197,7 +197,7 @@ const rendered = await Promise.all(
                         }
                     </ol>
                 </section>
-        <SiteFooter backToTopHref="#top" />
+        <SiteFooter backToTopHref="#main" />
         </main>
     </div>
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -17,7 +17,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
     <NavCapsule items={SITE.nav} />
     <MobileMenu items={SITE.nav} />
     <div class="page">
-        <main class="page-body">
+        <main id="main" class="page-body">
             <div class="section-stack">
                 <Hero />
                 <Now />

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,0 +1,12 @@
+import type { APIRoute } from "astro";
+
+// Generated from `Astro.site` (astro.config.mjs) so the Sitemap URL
+// stays in sync with the canonical origin. Replaces a hand-written
+// public/robots.txt that duplicated the production hostname.
+export const GET: APIRoute = ({ site }) => {
+    const sitemap = new URL("sitemap-index.xml", site).href;
+    const body = `User-agent: *\nDisallow:\n\nSitemap: ${sitemap}\n`;
+    return new Response(body, {
+        headers: { "Content-Type": "text/plain; charset=utf-8" },
+    });
+};


### PR DESCRIPTION
## Summary

First of several pre-launch SEO + accessibility PRs from `RELEASE_CHECKLIST.md`.

- **Canonical URL** built from `Astro.url.pathname` + `Astro.site`.
- **Open Graph + Twitter Card** meta with `og:type`, `og:title`,
  `og:description`, `og:url`, `og:site_name`, `og:locale`, `og:image`,
  and the Twitter equivalents. `og:image` resolves to `/og.png` — that
  route ships in a follow-up PR (Satori + resvg, both already
  installed).
- **JSON-LD `Person` schema** with `sameAs` linking to
  GitHub (`DanielChomat`) and LinkedIn (`danielchomat`). Rendered on
  every page; identical payload is the recommended pattern for personal
  sites.
- **Skip link** as the first focusable element inside `.wf`. Hidden
  off-screen until `:focus-visible`, honors `prefers-reduced-motion`.
- **`<main id="main">`** on every page. `/experience` switches from
  `id="top"` → `id="main"`; the `SiteFooter` back-to-top reference
  updates with it (same anchor, better semantics).
- **`robots.txt`** now references the generated sitemap.

## Test plan

- [ ] `yarn check:astro` clean
- [ ] `yarn build` clean
- [ ] View source on `/`, `/experience`, `/404` — confirm canonical,
      OG tags, JSON-LD, and skip link are all in the HTML
- [ ] Tab once into the page — skip link should slide into view
- [ ] Activate the skip link — focus jumps to `<main>`
- [ ] `/experience` → "Back to top" footer link still works
- [ ] `dist/sitemap-index.xml` exists; `/robots.txt` points at it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved social media sharing with enhanced metadata (titles, descriptions, images) for better page previews when shared on social platforms
  * Added keyboard accessibility shortcut to skip navigation elements and jump directly to main content

* **Chores**
  * Updated search engine discovery configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DanielChomat/chomat.tech/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->