### PR TITLE
refine(typography): curly apostrophes, NBSPs, text-wrap: balance

### DIFF
--- a/src/content/experience/freelance.mdx
+++ b/src/content/experience/freelance.mdx
@@ -18,6 +18,6 @@ order: 1
 ---
 
 A two-year umbrella covering a string of client engagements:
-greenfield React Native work for a US medical startup via
+greenfield React&nbsp;Native work for a US medical startup via
 GlobalLogic, an FX banking rewrite at Purple Next, and a handful
 of smaller pieces in between.

--- a/src/content/projects/usmed.mdx
+++ b/src/content/projects/usmed.mdx
@@ -18,6 +18,6 @@ order: 1
 ---
 
 Joined a small team building the companion app for a US medical
-startup's measuring device. Worked directly with the client through
+startup’s measuring device. Worked directly with the client through
 frequent demos, shaped architecture and deployment from the ground
-up, and shipped a greenfield React Native + Expo product end to end.
+up, and shipped a greenfield React&nbsp;Native + Expo product end to end.

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -29,7 +29,7 @@ export const SITE = {
         statusBold: "Partners Bank",
         statusTrail: " — mobile engineer.",
         statusMuted: "Open to interesting projects, freelance, conversations.",
-        ctaPrimary: "See what I'm building",
+        ctaPrimary: "See what I’m building",
         ctaPrimaryHref: "#now",
         ctaSecondary: "Resume.pdf",
         ctaSecondaryHref: "/resume.pdf",
@@ -53,7 +53,7 @@ export const SITE = {
         link: { label: "full timeline", href: "/experience" },
         headingMain: "Six years,",
         headingMuted: "three chapters.",
-        intro: "Web → mobile, agency → product, contractor → in-house. Partners Bank twice on purpose.",
+        intro: "Web → mobile, agency → product, contractor → in-house. Partners Bank twice on purpose.",
         currentLabel: "Currently here",
     },
     work: {
@@ -109,7 +109,7 @@ export const SITE = {
         kicker: "Contact",
         note: "prefers async",
         headingMain: "Reach out.",
-        headingMuted: "I'm probably building.",
+        headingMuted: "I’m probably building.",
         cards: {
             github: {
                 href: "https://github.com/DanielChomat",
@@ -149,7 +149,7 @@ export const SITE = {
         about: {
             kicker: "§ About · short version",
             headingLead: "Half-nomadic — ",
-            headingMark: "working from wherever the surf's decent",
+            headingMark: "working from wherever the surf’s decent",
             headingTrail: ". Run most mornings, build things most evenings.",
             pills: ["nomad", "surf", "run", "build"],
         },
@@ -190,8 +190,8 @@ export const SITE = {
     },
     notFound: {
         kicker: "error / not_found",
-        headingMark: "This URL doesn't resolve",
-        headingTrail: " to anything I've built — yet.",
+        headingMark: "This URL doesn’t resolve",
+        headingTrail: " to anything I’ve built — yet.",
         body: "Could be a stale link, a future page, or a typo. The site is small enough that you can probably find what you wanted from one of these.",
         cards: [
             {

--- a/src/styles/type.css
+++ b/src/styles/type.css
@@ -11,6 +11,7 @@
             font-weight: 500;
             margin: 0;
             overflow-wrap: break-word;
+            text-wrap: balance;
         }
         & .t-title {
             font-size: 1.0625rem;
@@ -66,6 +67,7 @@
                 font-weight: 500;
                 margin: 0;
                 overflow-wrap: break-word;
+                text-wrap: balance;
             }
             & .kicker {
                 font-size: 0.75rem;


### PR DESCRIPTION
## Summary

Small typography sweep, pre-launch polish:

- **Curly apostrophes** in user-visible prose. Six straight `'`
  converted to typographic `’`:
  - `I'm` → `I’m` (×2 in `site.ts`)
  - `surf's` → `surf’s`
  - `doesn't` → `doesn’t`
  - `I've` → `I’ve`
  - `startup's` → `startup’s` (in `usmed.mdx`)
- **Non-breaking spaces** in three compound-brand mentions, so
  these don't break mid-name on narrow viewports:
  - `Partners Bank` in the experience intro
  - `React Native` in `freelance.mdx` and `usmed.mdx` prose
  - Frontmatter / pill list mentions are left untouched — they
    render in their own boxes and don't wrap.
- **`text-wrap: balance`** on `.t-mega` and `.t-heading` so
  headings get an even ragged edge — no lonely-word widows on
  the last line.

## Test plan

- [ ] `yarn check:astro` clean
- [ ] `yarn build` clean
- [ ] On a narrow viewport (~375 px), confirm the experience
      intro keeps "Partners Bank" on one line
- [ ] Headings on `/` (hero, section heads) and `/experience`
      look balanced — no single trailing word on the last line

🤖 Generated with [Claude Code](https://claude.com/claude-code)