### PR TITLE
fix(a11y): hide decorative arrow glyphs from screen readers

### DIFF
--- a/src/components/homepage/Contact.astro
+++ b/src/components/homepage/Contact.astro
@@ -31,7 +31,7 @@ const { github, linkedin, resume } = contact.cards;
                 <p class="t-body">{github.blurb}</p>
                 <div class="card-foot">
                     <span class="t-mono">{github.foot}</span>
-                    <span class="t-mono accent">↗</span>
+                    <span class="t-mono accent" aria-hidden="true">↗</span>
                 </div>
             </a>
         </div>
@@ -42,7 +42,7 @@ const { github, linkedin, resume } = contact.cards;
                 <p class="t-body">{linkedin.blurb}</p>
                 <div class="card-foot">
                     <span class="t-mono">{linkedin.foot}</span>
-                    <span class="t-mono accent">↗</span>
+                    <span class="t-mono accent" aria-hidden="true">↗</span>
                 </div>
             </a>
         </div>
@@ -53,7 +53,7 @@ const { github, linkedin, resume } = contact.cards;
                 <p class="t-body muted">{resume.blurb}</p>
                 <div class="card-foot">
                     <span class="t-mono muted">{resume.foot}</span>
-                    <span class="t-mono accent">↓</span>
+                    <span class="t-mono accent" aria-hidden="true">↓</span>
                 </div>
             </a>
         </div>

--- a/src/components/homepage/Now.astro
+++ b/src/components/homepage/Now.astro
@@ -120,7 +120,7 @@ const tints: Record<string, string> = {
                                 </li>
                             ))}
                         </ul>
-                        <span class="t-mono accent">→</span>
+                        <span class="t-mono accent" aria-hidden="true">→</span>
                     </div>
                 </article>
             ))

--- a/src/components/homepage/Tech.astro
+++ b/src/components/homepage/Tech.astro
@@ -74,7 +74,7 @@ const { Content: AboutContent } = await render(aboutEntry);
                 </div>
                 <div class="divider stack-bottom-divider"></div>
                 <div class="t-mono muted stack-footnote">
-                    <span class="accent">→</span>&nbsp;&nbsp; {tech.footnote.lead}{" "}
+                    <span class="accent" aria-hidden="true">→</span>&nbsp;&nbsp; {tech.footnote.lead}{" "}
                     <strong class="footnote-tool">{tech.footnote.tool}</strong>
                     {tech.footnote.trail}
                 </div>

--- a/src/components/nav/NavCapsule.astro
+++ b/src/components/nav/NavCapsule.astro
@@ -16,7 +16,7 @@ const { items, active = -1 } = Astro.props;
         aria-label="Back to top"
         data-back-to-top
     >
-        ↑
+        <span aria-hidden="true">↑</span>
     </a>
     <span class="active-pill" data-active-pill aria-hidden="true"></span>
     {

--- a/src/pages/experience.astro
+++ b/src/pages/experience.astro
@@ -46,7 +46,7 @@ const rendered = await Promise.all(
                         <span class="exp-crumb-home-label">{copy.homeCrumb}</span>
                     </a>
                     <a class="t-mono accent" href="/resume.pdf">
-                        ↓ {copy.resumeLink}
+                        <span aria-hidden="true">↓</span> {copy.resumeLink}
                     </a>
                 </nav>
 


### PR DESCRIPTION
## Summary

Six decorative arrow glyphs were inside interactive elements without
`aria-hidden`, so screen readers were announcing things like
"@DanielChomat northeast arrow" or "downward arrow resume.pdf."

Fixed by either wrapping the glyph in `<span aria-hidden="true">` or
adding the attribute to the existing span:

- **`Contact.astro`** — three card-foot arrows (↗ ↗ ↓) inside
  GitHub / LinkedIn / Resume links
- **`Now.astro`** — the per-project "→" indicator
- **`Tech.astro`** — the footnote-lead "→"
- **`NavCapsule.astro`** — the "↑" inside Back-to-top (belt-and-braces;
  the anchor's `aria-label="Back to top"` already wins)
- **`/experience`** — the "↓" before "resume.pdf" in the breadcrumb row

Already-hidden glyphs were left alone:
- `404.astro`'s "✕" lives inside `.nf-glyph aria-hidden="true"`
- `/experience`'s Home-crumb "←" already has the attribute

## Heading audit (also performed, no changes needed)

Hierarchy is clean across all three pages — one `<h1>` per page
(Hero / exp-title / nf-heading); no `h2→h4` skips. The `<h3>` on the
homepage Experience-card company name is intentional (section `<h2>`
above it).

## Test plan

- [ ] `yarn check:astro` clean
- [ ] `yarn build` clean
- [ ] VoiceOver or NVDA pass over Contact, Now, Tech, NavCapsule:
      no spurious "arrow" / "northeast arrow" announcements

🤖 Generated with [Claude Code](https://claude.com/claude-code)