### PR TITLE
feat(redesign): logomark monogram + spritz palette + theme-color metas

### DIFF
--- a/src/components/homepage/Companies.astro
+++ b/src/components/homepage/Companies.astro
@@ -1,15 +1,25 @@
 ---
 import { getCollection } from "astro:content";
+import { SITE } from "../../data/site.ts";
+import LogoMark from "../primitives/LogoMark.astro";
 
 const companies = (await getCollection("companies")).sort((a, b) => a.data.order - b.data.order);
+const { companies: copy } = SITE;
 ---
 
 <section class="companies-section" aria-label="Companies I've worked with">
-    <div class="card faintbg companies-card">
-        <ul class="logo-strip">
+    <div class="card companies-card">
+        <div class="companies-label">
+            <span class="t-mono accent">● {copy.label}</span>
+            <span class="t-mono muted">{copy.range} · {companies.length} companies</span>
+        </div>
+        <ul class="companies-strip">
             {
                 companies.map((c) => (
-                    <li class="logo">{c.data.name}</li>
+                    <li class="companies-item">
+                        <LogoMark name={c.data.name} size={56} />
+                        <span class="t-mono muted companies-name">{c.data.name}</span>
+                    </li>
                 ))
             }
         </ul>
@@ -17,18 +27,75 @@ const companies = (await getCollection("companies")).sort((a, b) => a.data.order
 </section>
 
 <style>
+    /* Coda to the Work/projects section: pull the thin strip up out of the
+       6.25rem section-stack gap so it hugs projects, and trim the gap below
+       (to Tech) too — otherwise the strip floats in whitespace on both sides. */
     .companies-section {
-        margin-top: 1.75rem;
+        margin-top: -4rem;
+        margin-bottom: -3.5rem;
     }
+    /* .card defaults to a column; lay the strip out as label + logos row.
+       Faint single-hue wash (neutral surface-2 → a touch of cool sky) so the
+       strip reads as a calm distinct band, not a rainbow. Token-driven, so it
+       deepens in dark mode. */
     .companies-card {
-        padding: 1.25rem 1.75rem;
+        flex-direction: row;
+        align-items: center;
+        gap: 1.375rem;
+        padding: 1.25rem 1.625rem;
+        background: linear-gradient(
+            100deg,
+            var(--surface-2),
+            color-mix(in oklab, var(--tint-sky) 35%, var(--surface))
+        );
+        border-color: color-mix(in oklab, var(--tint-sky) 35%, var(--line));
     }
-    /* V3Companies overrides the base `.logo` per-instance to a taller,
-       slightly larger label (28px / 11px vs the partial's 22px / 10px).
-       Scope the bump here so the partial defaults stay correct for any
-       future logo-strip usage. */
-    .companies-card :global(.logo-strip .logo) {
-        height: 1.75rem;
-        font-size: 0.6875rem;
+    .companies-label {
+        display: flex;
+        flex-direction: column;
+        gap: 0.125rem;
+        flex: none;
+        width: 8.25rem;
+    }
+    .companies-strip {
+        display: flex;
+        align-items: center;
+        justify-content: space-around;
+        gap: 1.125rem;
+        flex: 1;
+        flex-wrap: wrap;
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+    .companies-item {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.375rem;
+    }
+    .companies-name {
+        font-size: 0.625rem;
+        letter-spacing: 0;
+    }
+
+    @media (max-width: 45rem) {
+        /* Smaller stack gap on mobile (2.5rem), so a gentler pull on both sides. */
+        .companies-section {
+            margin-top: -0.75rem;
+            margin-bottom: -0.75rem;
+        }
+        .companies-card {
+            flex-direction: column;
+            align-items: flex-start;
+            gap: 1rem;
+        }
+        .companies-label {
+            width: auto;
+        }
+        .companies-strip {
+            justify-content: flex-start;
+            gap: 1rem;
+        }
     }
 </style>

--- a/src/components/homepage/Companies.astro
+++ b/src/components/homepage/Companies.astro
@@ -7,7 +7,7 @@ const companies = (await getCollection("companies")).sort((a, b) => a.data.order
 const { companies: copy } = SITE;
 ---
 
-<section class="companies-section" aria-label="Companies I've worked with">
+<section aria-label="Companies I've worked with">
     <div class="card companies-card">
         <div class="companies-label">
             <span class="t-mono accent">● {copy.label}</span>
@@ -27,13 +27,8 @@ const { companies: copy } = SITE;
 </section>
 
 <style>
-    /* Coda to the Work/projects section: pull the thin strip up out of the
-       6.25rem section-stack gap so it hugs projects, and trim the gap below
-       (to Tech) too — otherwise the strip floats in whitespace on both sides. */
-    .companies-section {
-        margin-top: -4rem;
-        margin-bottom: -3.5rem;
-    }
+    /* The strip sits in the normal section-stack rhythm (the stack's own
+       6.25rem gap), same as every other section — no margin hacks. */
     /* .card defaults to a column; lay the strip out as label + logos row.
        Faint single-hue wash (neutral surface-2 → a touch of cool sky) so the
        strip reads as a calm distinct band, not a rainbow. Token-driven, so it
@@ -80,11 +75,6 @@ const { companies: copy } = SITE;
     }
 
     @media (max-width: 45rem) {
-        /* Smaller stack gap on mobile (2.5rem), so a gentler pull on both sides. */
-        .companies-section {
-            margin-top: -0.75rem;
-            margin-bottom: -0.75rem;
-        }
         .companies-card {
             flex-direction: column;
             align-items: flex-start;

--- a/src/components/homepage/Experience.astro
+++ b/src/components/homepage/Experience.astro
@@ -4,6 +4,7 @@ import { formatIntervals, isCurrent, tintClass } from "../../data/format.ts";
 import { SITE } from "../../data/site.ts";
 import HandArrow from "../primitives/HandArrow.astro";
 import Kicker from "../primitives/Kicker.astro";
+import LogoMark from "../primitives/LogoMark.astro";
 import StatusPill from "../primitives/StatusPill.astro";
 
 const { experience: copy } = SITE;
@@ -36,7 +37,8 @@ const entries = (await getCollection("experience")).sort((a, b) => a.data.order 
         {
             entries.map((x, i) => {
                 const current = isCurrent(x.data.intervals);
-                const tint = x.data.tint ? tintClass(x.data.tint) : "";
+                // Only the current role gets a tinted card; past roles stay neutral.
+                const tint = current && x.data.tint ? tintClass(x.data.tint) : "";
                 return (
                     <div class="col-4">
                         <article class:list={["card", tint]}>
@@ -47,8 +49,13 @@ const entries = (await getCollection("experience")).sort((a, b) => a.data.order 
                                 )}
                             </div>
                             <div class="t-mono">{formatIntervals(x.data.intervals)}</div>
-                            <h3 class="t-title">{x.data.company}</h3>
-                            <div class="t-body muted">{x.data.title}</div>
+                            <div class="row experience-id">
+                                <LogoMark name={x.data.company} />
+                                <div class="experience-id-text">
+                                    <h3 class="t-title">{x.data.company}</h3>
+                                    <div class="t-mono muted">{x.data.title}</div>
+                                </div>
+                            </div>
                             <p class="t-body pull-bottom">{x.data.summary}</p>
                         </article>
                     </div>
@@ -68,5 +75,14 @@ const entries = (await getCollection("experience")).sort((a, b) => a.data.order 
     }
     .bento-pad-top {
         margin-top: 1.375rem;
+    }
+    .experience-id {
+        gap: 0.625rem;
+        margin-top: 0.5rem;
+    }
+    .experience-id-text {
+        display: flex;
+        flex-direction: column;
+        gap: 0.125rem;
     }
 </style>

--- a/src/components/homepage/Hero.astro
+++ b/src/components/homepage/Hero.astro
@@ -28,25 +28,22 @@ const { status } = hero;
         </div>
 
         <div class="hero-status-block">
-            <h2 class="t-title hero-status-h">Back at <strong>Partners Bank</strong>.</h2>
-            <p class="t-body muted hero-status-sub">
-                Mobile engineer on v2 of the Czech app-only retail bank.
-            </p>
+            <h3 class="t-title hero-status-h">
+                {status.roleLead}<strong>{status.roleBold}</strong>{status.roleTrail}
+            </h3>
+            <p class="t-body muted hero-status-sub">{status.roleBody}</p>
         </div>
 
         <div class="divider"></div>
 
         <div class="hero-status-block">
-            <h2 class="t-title hero-status-h">Building <strong>Moments</strong>.</h2>
-            <p class="t-body hero-status-body">
-                A pocket camcorder for the small ones — retro grain, no feed, no
-                algorithm. A Spanish tax tool and a pregnancy companion are in flight too.
-            </p>
+            <h3 class="t-title hero-status-h">
+                {status.buildingLead}<strong>{status.buildingBold}</strong>{status.buildingTrail}
+            </h3>
+            <p class="t-body hero-status-body">{status.buildingBody}</p>
         </div>
 
-        <p class="t-body muted hero-status-avail">
-            Open to freelance and good async conversations.
-        </p>
+        <p class="t-body muted hero-status-avail">{status.availability}</p>
 
         <div class="row-tight hero-status-cta">
             <a class="btn accent" href={status.ctaPrimaryHref}>

--- a/src/components/homepage/Hero.astro
+++ b/src/components/homepage/Hero.astro
@@ -4,10 +4,11 @@ import HandArrow from "../primitives/HandArrow.astro";
 import Kicker from "../primitives/Kicker.astro";
 
 const { hero } = SITE;
+const { status } = hero;
 ---
 
-<section id="hero">
-    <div class="hero-stack">
+<section id="hero" class="bento hero-bento">
+    <div class="col-8 hero-stack">
         <Kicker>{hero.kicker}</Kicker>
         <h1 class="t-mega">
             {hero.name}<span class="accent">*</span>
@@ -20,21 +21,40 @@ const { hero } = SITE;
         </p>
     </div>
 
-    <div class="hero-cta-row">
-        <div class="row hero-status">
+    <aside class="col-4 card hero-status-card" aria-label="What I'm working on now">
+        <div class="row row-between">
+            <Kicker>{status.kicker}</Kicker>
             <span class="status-dot pulse hero-status-dot"></span>
-            <span class="t-body">
-                {hero.statusLead}<strong>{hero.statusBold}</strong>{hero.statusTrail}
-                <span class="muted hero-status-muted">{hero.statusMuted}</span>
-            </span>
         </div>
-        <div class="row-tight">
-            <a class="btn accent" href={hero.ctaPrimaryHref}>
-                {hero.ctaPrimary} <HandArrow />
+
+        <div class="hero-status-block">
+            <h2 class="t-title hero-status-h">Back at <strong>Partners Bank</strong>.</h2>
+            <p class="t-body muted hero-status-sub">
+                Mobile engineer on v2 of the Czech app-only retail bank.
+            </p>
+        </div>
+
+        <div class="divider"></div>
+
+        <div class="hero-status-block">
+            <h2 class="t-title hero-status-h">Building <strong>Moments</strong>.</h2>
+            <p class="t-body hero-status-body">
+                A pocket camcorder for the small ones — retro grain, no feed, no
+                algorithm. A Spanish tax tool and a pregnancy companion are in flight too.
+            </p>
+        </div>
+
+        <p class="t-body muted hero-status-avail">
+            Open to freelance and good async conversations.
+        </p>
+
+        <div class="row-tight hero-status-cta">
+            <a class="btn accent" href={status.ctaPrimaryHref}>
+                {status.ctaPrimary} <HandArrow />
             </a>
-            <a class="btn" href={hero.ctaSecondaryHref}>{hero.ctaSecondary}</a>
+            <a class="btn" href={status.ctaSecondaryHref}>{status.ctaSecondary}</a>
         </div>
-    </div>
+    </aside>
 </section>
 
 <style>
@@ -49,37 +69,41 @@ const { hero } = SITE;
         line-height: 1.55;
         margin-top: 0.375rem;
     }
-    .hero-status {
-        gap: 0.875rem;
+    /* Size the card to its own content instead of stretching to match the
+       tall mega-name column it sits beside. */
+    .hero-status-card {
+        align-self: start;
     }
     .hero-status-dot {
         width: 0.625rem;
         height: 0.625rem;
     }
-    .hero-status-muted {
-        margin-left: 0.25rem;
+    /* Group each block so its heading and caption hug (0.25rem), while the
+       card's own 0.75rem flex gap spaces the blocks, divider, and CTAs. */
+    .hero-status-block {
+        display: grid;
+        gap: 0.25rem;
+    }
+    .hero-status-sub,
+    .hero-status-avail {
+        font-size: 0.8125rem;
+    }
+    .hero-status-cta {
+        margin-top: 0.25rem;
     }
 
     @media (max-width: 45rem) {
-        .hero-status {
-            align-items: flex-start;
+        /* On phones the card stacks under the name (the .col-* collapse in
+           utilities.css); let the CTAs go full-width like the old hero row. */
+        .hero-status-cta {
+            width: 100%;
+            flex-direction: column;
+            align-items: stretch;
             gap: 0.5rem;
-            padding: 0.75rem 0.875rem;
-            background: color-mix(in oklab, var(--accent) 14%, var(--surface));
-            border: 1px solid color-mix(in oklab, var(--accent) 30%, var(--line));
-            border-radius: var(--radius);
-            box-shadow: var(--shadow);
         }
-        .hero-status-dot {
-            margin-top: 0.3125rem;
-        }
-        .hero-status-muted {
-            display: block;
-            margin-left: 0;
-            margin-top: 0.125rem;
-            font-family: var(--font-mono);
-            font-size: 0.6875rem;
-            letter-spacing: 0.04em;
+        .hero-status-cta .btn {
+            width: 100%;
+            justify-content: center;
         }
     }
 </style>

--- a/src/components/nav/ThemeToggle.astro
+++ b/src/components/nav/ThemeToggle.astro
@@ -62,9 +62,28 @@
         // Nothing more to do — the inline pre-paint script in BaseLayout
         // already established the theme.
     } else {
-        const themeColors = { light: "#f8f5ec", dark: "#0e0d0a" } as const;
+        // Toggle the `media` attribute on the two theme-color metas so iOS
+        // Safari picks the right one. `explicit=true` forces a specific
+        // theme regardless of OS preference; `explicit=false` restores the
+        // natural (prefers-color-scheme) queries.
+        const lightMeta = document.querySelector<HTMLMetaElement>(
+            'meta[name="theme-color"][data-theme-color="light"]'
+        );
+        const darkMeta = document.querySelector<HTMLMetaElement>(
+            'meta[name="theme-color"][data-theme-color="dark"]'
+        );
+        const applyThemeColor = (theme: "light" | "dark", explicit: boolean) => {
+            if (!lightMeta || !darkMeta) return;
+            if (explicit) {
+                lightMeta.media = theme === "dark" ? "not all" : "all";
+                darkMeta.media = theme === "dark" ? "all" : "not all";
+            } else {
+                lightMeta.media = "(prefers-color-scheme: light)";
+                darkMeta.media = "(prefers-color-scheme: dark)";
+            }
+        };
 
-        const sync = (theme: "light" | "dark") => {
+        const syncButton = (theme: "light" | "dark") => {
             const isDark = theme === "dark";
             button.setAttribute("aria-pressed", isDark ? "true" : "false");
             button.setAttribute(
@@ -72,14 +91,9 @@
                 isDark ? "Switch to light mode" : "Switch to dark mode"
             );
             button.setAttribute("title", isDark ? "Dark" : "Light");
-            const meta = document.querySelector<HTMLMetaElement>(
-                'meta[name="theme-color"]'
-            );
-            if (meta) meta.setAttribute("content", themeColors[theme]);
         };
 
-        const current = (root.dataset.theme === "dark" ? "dark" : "light");
-        sync(current);
+        syncButton(root.dataset.theme === "dark" ? "dark" : "light");
 
         button.addEventListener("click", () => {
             const next = root.dataset.theme === "dark" ? "light" : "dark";
@@ -89,7 +103,8 @@
             } catch {
                 /* storage disabled — fall through */
             }
-            sync(next);
+            syncButton(next);
+            applyThemeColor(next, true);
         });
 
         // Track OS preference changes while no explicit choice is stored.
@@ -102,7 +117,8 @@
             }
             const next = event.matches ? "dark" : "light";
             root.dataset.theme = next;
-            sync(next);
+            syncButton(next);
+            applyThemeColor(next, false);
         };
         mq.addEventListener("change", onChange);
     }

--- a/src/components/primitives/LogoMark.astro
+++ b/src/components/primitives/LogoMark.astro
@@ -1,0 +1,21 @@
+---
+import { initials, tintClass } from "../../data/format.ts";
+
+type Props = {
+    /** Company / brand name; the monogram is derived from its initials. */
+    name: string;
+    /** Tile size in design-px units; rendered as rem (px / 16). Default 36. */
+    size?: number;
+    /** Tint token (butter, sage, sky, …); falls back to the neutral surface. */
+    tint?: string;
+};
+
+const { name, size, tint } = Astro.props;
+const mono = initials(name);
+const sizeRem = size ? `${size / 16}rem` : undefined;
+---
+
+<span
+    class:list={["logomark", tintClass(tint)]}
+    style={sizeRem ? `--logo-size: ${sizeRem};` : undefined}
+    aria-hidden="true">{mono}</span>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -55,7 +55,22 @@ const experience = defineCollection({
         tech: z.array(z.string()).default([]),
         nda: z.boolean().default(false),
         summary: z.string(),
-        tint: z.enum(["butter", "sage", "rose", "sky", "lavender", "teal", ""]).default(""),
+        tint: z
+            .enum([
+                "butter",
+                "sage",
+                "rose",
+                "sky",
+                "lavender",
+                "mint",
+                "blossom",
+                "coral",
+                "peach",
+                "lime",
+                "teal",
+                "",
+            ])
+            .default(""),
         order: z.number().default(0),
     }),
 });

--- a/src/data/format.ts
+++ b/src/data/format.ts
@@ -53,10 +53,25 @@ const TINT_MAP: Record<string, string> = {
     rose: "tint-rose",
     sky: "tint-sky",
     lavender: "tint-lavender",
+    mint: "tint-mint",
+    blossom: "tint-blossom",
+    coral: "tint-coral",
+    peach: "tint-peach",
+    lime: "tint-lime",
     teal: "tint-teal",
 };
 
 export function tintClass(tone?: string): string {
     if (!tone) return "";
     return TINT_MAP[tone] ?? "";
+}
+
+/** Up-to-two-letter monogram from a name: "Partners Bank" → "PB". */
+export function initials(name: string): string {
+    return name
+        .split(/\s+/)
+        .map((w) => w[0] ?? "")
+        .join("")
+        .slice(0, 2)
+        .toUpperCase();
 }

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -25,14 +25,15 @@ export const SITE = {
         bioMid: ", and agencies. Now turning that ",
         bioMarkAlt: "toward my own products",
         bioAfter: " — and writing about it as I go.",
-        statusLead: "Back at ",
-        statusBold: "Partners Bank",
-        statusTrail: " — mobile engineer.",
-        statusMuted: "Open to interesting projects, freelance, conversations.",
-        ctaPrimary: "See what I’m building",
-        ctaPrimaryHref: "#now",
-        ctaSecondary: "Resume.pdf",
-        ctaSecondaryHref: "/resume.pdf",
+        status: {
+            // The card's prose is authored as markup in Hero.astro; only the
+            // eyebrow kicker and the two CTAs (link config) live here.
+            kicker: "/now · May 2026",
+            ctaPrimary: "See what I’m building",
+            ctaPrimaryHref: "#now",
+            ctaSecondary: "Resume.pdf",
+            ctaSecondaryHref: "/resume.pdf",
+        },
     },
     now: {
         number: "01",
@@ -55,6 +56,10 @@ export const SITE = {
         headingMuted: "three chapters.",
         intro: "Web → mobile, agency → product, contractor → in-house. Partners Bank twice on purpose.",
         currentLabel: "Currently here",
+    },
+    companies: {
+        label: "Worked with",
+        range: "2019 → now",
     },
     work: {
         number: "§03",

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -26,9 +26,20 @@ export const SITE = {
         bioMarkAlt: "toward my own products",
         bioAfter: " — and writing about it as I go.",
         status: {
-            // The card's prose is authored as markup in Hero.astro; only the
-            // eyebrow kicker and the two CTAs (link config) live here.
+            // All status-card copy lives here so Hero.astro stays render-only:
+            // the eyebrow kicker, the two status blocks (each a lead/bold/trail
+            // heading + body line), the availability line, and the two CTAs.
             kicker: "/now · May 2026",
+            roleLead: "Back at ",
+            roleBold: "Partners Bank",
+            roleTrail: ".",
+            roleBody: "Mobile engineer on v2 of the Czech app-only retail bank.",
+            buildingLead: "Building ",
+            buildingBold: "Moments",
+            buildingTrail: ".",
+            buildingBody:
+                "A pocket camcorder for the small ones — retro grain, no feed, no algorithm. A Spanish tax tool and a pregnancy companion are in flight too.",
+            availability: "Open to freelance and good async conversations.",
             ctaPrimary: "See what I’m building",
             ctaPrimaryHref: "#now",
             ctaSecondary: "Resume.pdf",

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -40,7 +40,12 @@ const personSchema = {
         <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
         <link rel="manifest" href="/site.webmanifest" />
         <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-        <meta name="theme-color" content="#f8f5ec" />
+        <!-- Two declarative metas so iOS Safari paints the URL bar / toolbar
+             tint correctly on first frame, before the bootstrap script
+             runs. The toggle script later flips their `media` attributes
+             when the user picks a theme that doesn't match the OS. -->
+        <meta name="theme-color" content="#f3efe4" media="(prefers-color-scheme: light)" data-theme-color="light" />
+        <meta name="theme-color" content="#0e0d0a" media="(prefers-color-scheme: dark)" data-theme-color="dark" />
         <meta name="color-scheme" content="light dark" />
         <meta name="generator" content={Astro.generator} />
         <meta name="description" content={description} />
@@ -82,12 +87,22 @@ const personSchema = {
                               ? "dark"
                               : "light";
                     document.documentElement.dataset.theme = theme;
-                    var meta = document.querySelector('meta[name="theme-color"]');
-                    if (meta)
-                        meta.setAttribute(
-                            "content",
-                            theme === "dark" ? "#0e0d0a" : "#f8f5ec"
+                    // If a stored choice overrides the OS preference, swap
+                    // the theme-color metas so the iOS chrome matches the
+                    // page. When the stored theme matches the OS, the two
+                    // (prefers-color-scheme) metas already do the right thing.
+                    if (stored && (stored === "dark") !== prefersDark) {
+                        var lm = document.querySelector(
+                            'meta[name="theme-color"][data-theme-color="light"]'
                         );
+                        var dm = document.querySelector(
+                            'meta[name="theme-color"][data-theme-color="dark"]'
+                        );
+                        if (lm && dm) {
+                            lm.media = theme === "dark" ? "not all" : "all";
+                            dm.media = theme === "dark" ? "all" : "not all";
+                        }
+                    }
                 } catch (err) {
                     document.documentElement.dataset.theme = "light";
                 }
@@ -95,7 +110,7 @@ const personSchema = {
         </script>
     </head>
     <body>
-        <div class="wf v3 pal-newsprint">
+        <div class="wf v3 pal-spritz">
             <a class="skip-link" href="#main">Skip to content</a>
             <ThemeToggle />
             {/* SoundToggle parked until an audio feature exists — see import. */}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -23,8 +23,8 @@ import BaseLayout from "../layouts/BaseLayout.astro";
                 <Now />
                 <Experience />
                 <Work />
-                <Tech />
                 <Companies />
+                <Tech />
                 <Contact />
             </div>
             <SiteFooter />

--- a/src/styles/components/card.css
+++ b/src/styles/components/card.css
@@ -38,6 +38,26 @@
                 background: var(--tint-lavender);
                 border-color: color-mix(in oklab, var(--tint-lavender) 60%, var(--line));
             }
+            &.tint-mint {
+                background: var(--tint-mint);
+                border-color: color-mix(in oklab, var(--tint-mint) 60%, var(--line));
+            }
+            &.tint-blossom {
+                background: var(--tint-blossom);
+                border-color: color-mix(in oklab, var(--tint-blossom) 60%, var(--line));
+            }
+            &.tint-coral {
+                background: var(--tint-coral);
+                border-color: color-mix(in oklab, var(--tint-coral) 60%, var(--line));
+            }
+            &.tint-peach {
+                background: var(--tint-peach);
+                border-color: color-mix(in oklab, var(--tint-peach) 60%, var(--line));
+            }
+            &.tint-lime {
+                background: var(--tint-lime);
+                border-color: color-mix(in oklab, var(--tint-lime) 60%, var(--line));
+            }
             &.tint-teal {
                 background: color-mix(in oklab, var(--accent) 14%, var(--surface));
                 border-color: color-mix(in oklab, var(--accent) 30%, var(--line));

--- a/src/styles/components/layout.css
+++ b/src/styles/components/layout.css
@@ -47,40 +47,6 @@
             }
         }
 
-        & .logo-strip {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            gap: 1.125rem;
-            list-style: none;
-            margin: 0;
-            padding: 0;
-            flex-wrap: wrap;
-
-            & .logo {
-                flex: 1 1 7rem;
-                height: 1.375rem;
-                background: var(--surface-2);
-                border-radius: 0.25rem;
-                display: flex;
-                align-items: center;
-                justify-content: center;
-                font-family: var(--font-mono);
-                font-size: 0.625rem;
-                color: var(--muted);
-                text-transform: uppercase;
-                letter-spacing: 0.06em;
-            }
-
-            @media (max-width: 45rem) {
-                justify-content: flex-start;
-                gap: 0.75rem;
-
-                & .logo {
-                    flex: 1 1 calc(50% - 0.375rem);
-                }
-            }
-        }
         & .wormhole-list {
             display: flex;
             gap: 0.875rem;
@@ -91,42 +57,14 @@
             flex-wrap: wrap;
         }
 
-        /* Hero */
+        /* Hero — name/bio column stack; the status card is a bento peer.
+           The 2-up split + mobile collapse come from the .bento / .col-*
+           utilities the hero section now uses. */
         & .hero-stack {
             display: grid;
             grid-template-columns: 1fr;
             gap: 1.75rem;
-        }
-        & .hero-cta-row {
-            display: grid;
-            grid-template-columns: 1.6fr auto;
-            gap: 1.375rem;
-            align-items: center;
-            margin-top: 2.25rem;
-            padding-top: 1.375rem;
-            border-top: 1px solid var(--line);
-
-            @media (max-width: 45rem) {
-                grid-template-columns: 1fr;
-                gap: 1rem;
-                margin-top: 1.5rem;
-                padding-top: 1rem;
-
-                /* Stack the two CTAs vertically and full-width; the previous
-                   flex: 1 forced a 50/50 split which squashed "See what I'm
-                   building" into two awkward lines next to a half-empty
-                   "Resume.pdf". */
-                & .row-tight {
-                    width: 100%;
-                    flex-direction: column;
-                    align-items: stretch;
-                    gap: 0.5rem;
-                }
-                & .btn {
-                    width: 100%;
-                    justify-content: center;
-                }
-            }
+            align-content: start;
         }
 
         /* Now */

--- a/src/styles/components/logomark.css
+++ b/src/styles/components/logomark.css
@@ -1,0 +1,40 @@
+/* Monogram tile — initials in a bordered, optionally-tinted square.
+   Stands in for a real wordmark. Used by the Experience cards and the
+   Companies "worked with" strip. Loaded into @layer components.
+
+   Size is driven by the `--logo-size` custom property: the component sets
+   it inline only when overriding the default (the single dynamic-var
+   exception to the no-inline-styles rule, per AGENTS.md). */
+
+@layer components {
+    .wf {
+        & .logomark {
+            --logo-size: 2.25rem;
+            width: var(--logo-size);
+            height: var(--logo-size);
+            flex: none;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            border: 1px solid var(--line);
+            border-radius: var(--radius-sm);
+            background: var(--surface-2);
+            font-family: var(--font-mono);
+            font-weight: 500;
+            font-size: calc(var(--logo-size) * 0.36);
+            letter-spacing: -0.02em;
+            color: var(--text);
+
+            &.tint-butter { background: var(--tint-butter); }
+            &.tint-sage { background: var(--tint-sage); }
+            &.tint-rose { background: var(--tint-rose); }
+            &.tint-sky { background: var(--tint-sky); }
+            &.tint-lavender { background: var(--tint-lavender); }
+            &.tint-mint { background: var(--tint-mint); }
+            &.tint-blossom { background: var(--tint-blossom); }
+            &.tint-coral { background: var(--tint-coral); }
+            &.tint-peach { background: var(--tint-peach); }
+            &.tint-lime { background: var(--tint-lime); }
+        }
+    }
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -21,6 +21,7 @@
 @import "./tokens.css";                 /* @layer base       */
 @import "./type.css";                   /* @layer base       */
 @import "./components/card.css";        /* @layer components */
+@import "./components/logomark.css";    /* @layer components */
 @import "./components/pill.css";        /* @layer components */
 @import "./components/controls.css";    /* @layer components */
 @import "./components/nav.css";         /* @layer components */

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -50,6 +50,36 @@
             --tint-lavender: #bfb1d5;
         }
 
+        /* Spritz — softer pastel set used by v6. Dialed-back chroma so the
+           tints read as colorful accents, not a riot. The site-wide palette. */
+        &.pal-spritz {
+            --bg: #f3efe4;
+            --surface: #fbf7eb;
+            --surface-2: #ebe5d4;
+            --line: rgba(40, 28, 12, 0.12);
+            --line-2: rgba(40, 28, 12, 0.06);
+            --tint-butter: oklch(93% 0.08 95);
+            --tint-sage: oklch(91% 0.07 145);
+            --tint-mint: oklch(91% 0.06 175);
+            --tint-sky: oklch(91% 0.06 230);
+            --tint-lavender: oklch(89% 0.07 295);
+            --tint-blossom: oklch(89% 0.07 350);
+            --tint-rose: oklch(89% 0.08 35);
+            --tint-coral: oklch(88% 0.09 22);
+            --tint-peach: oklch(91% 0.08 60);
+            --tint-lime: oklch(93% 0.1 120);
+        }
+
+        /* Warm wash — two low-contrast pastel blobs anchored to opposite
+           corners of the full-height root. Light mode only: the dark-token
+           selector below resets background to a flat var(--bg). */
+        html:not([data-theme="dark"]) &.pal-spritz {
+            background:
+                radial-gradient(75rem 56.25rem at 8% 0%, oklch(95% 0.07 80 / 0.55), transparent 60%),
+                radial-gradient(62.5rem 50rem at 100% 100%, oklch(94% 0.07 290 / 0.4), transparent 60%),
+                var(--bg);
+        }
+
         &.v3 {
             font-feature-settings:
                 "ss01" on,
@@ -63,7 +93,8 @@
            applied site-wide. Tints are deepened versions that still read
            warm. */
         html[data-theme="dark"] &,
-        html[data-theme="dark"] &.pal-newsprint {
+        html[data-theme="dark"] &.pal-newsprint,
+        html[data-theme="dark"] &.pal-spritz {
             --bg: #0e0d0a;
             --surface: #15140f;
             --surface-2: #1a1914;
@@ -82,6 +113,11 @@
             --tint-rose: #482620;
             --tint-sky: #1f2e3e;
             --tint-lavender: #2c2640;
+            --tint-mint: #1f3a32;
+            --tint-blossom: #3e1f2e;
+            --tint-coral: #4a2620;
+            --tint-peach: #4a3a1a;
+            --tint-lime: #2f3a1a;
         }
     }
 }


### PR DESCRIPTION
## Summary

V2 redesign polish, one coherent change:

- **LogoMark primitive** — initials-based monogram (`initials()` helper added to `format.ts`) + `logomark.css`, wired into the **Companies** and **Experience** logo strips.
- **`pal-spritz` palette** — new site-wide palette in `tokens.css` (oklch pastel tints + warm-wash background); `BaseLayout` switched to it.
- **Tint expansion** — experience `tint` enum gains `mint, blossom, coral, peach, lime` (`content.config.ts`) with matching `TINT_MAP` entries.
- **iOS theme-color** — dual `prefers-color-scheme` `<meta name="theme-color">` tags, kept in sync by `ThemeToggle`'s bootstrap + click handlers.
- Hero / Companies / Experience visual polish; card / layout / global CSS adjustments; minor site-copy tweaks.

## Verification

- `yarn check:astro` — clean (0 errors)
- `yarn build` — clean (3 pages)
- `npx biome check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced company logos and status card display on the homepage
  * Added experience logos with company details
  * Expanded color palette with new tint options (mint, blossom, coral, peach, lime)

* **Bug Fixes**
  * Improved iOS/Safari theme color handling

* **Style**
  * Redesigned Companies and Hero sections with enhanced layouts
  * Updated card and component visuals

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DanielChomat/chomat.tech/pull/83?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->