### PR TITLE
Refresh site copy: first-person voice, fact fixes, NiteOwl

### DIFF
--- a/CONTENT.md
+++ b/CONTENT.md
@@ -1,0 +1,210 @@
+# CONTENT.md — Copy editing kit for chomat.tech
+
+A self-contained brief for rewriting/updating any text on the site. **Hand the whole
+file to an LLM** (or use it yourself) and you won't need to re-analyze the codebase.
+
+> Scope: this file is about **words**. For *adding* a new project/experience/section
+> (scaffolding + schema), use the `/add-project`, `/add-experience`, `/add-section`
+> skills instead. For visual/CSS rules see `AGENTS.md`.
+
+---
+
+## 0. How to use this
+
+1. Find the text you want to change in the **Content map** (§3) → it tells you the
+   exact file + field.
+2. Paste this whole file into an LLM, then add your request (template in §7).
+3. The LLM returns edited file(s). Run `npm run build` — if frontmatter is valid and no
+   `SITE` key was dropped, it passes. Then `npm run dev` to eyeball.
+
+---
+
+## 1. Who it's for & the voice (don't relitigate)
+
+- **Subject:** Daniel Chomat — senior React Native / mobile product engineer, based in
+  Czechia. Six years across fintech, healthcare, startups, agency.
+- **Audience:** **broad personal brand** — balanced, identity-first. NOT a single
+  hiring or freelance funnel. Speak to peers, clients, and the curious alike.
+- **Voice:** **first person** ("I build…", "I shipped…"). Confident, tight, warm.
+  Terse over flowery. Salvage warmth ("worked like a charm") but cut filler
+  ("QA gurus", emoji headings).
+- **Settled decisions — keep unless Daniel revisits:**
+  - **No "Canada" / relocation messaging.** (Old Sanity bio + LinkedIn still say it;
+    it was deliberately dropped.)
+  - **"Six years (2019→)" framing.** Timeline = 3 entries (Refresh → Partners Bank →
+    Freelance). Earlier roles (Unicorn 2017, 2018–19 freelance) are only nodded to in
+    the About prose, never as timeline entries.
+  - **Languages = `EN / ES / CZ` pills, no proficiency labels, no French.**
+
+---
+
+## 2. Where copy lives — two layers
+
+1. **`src/data/site.ts`** — every section-level string (headings, kickers, CTAs, hero,
+   metadata, 404, footer). One big `SITE` object, `as const`. **Edit string values
+   only — never rename/remove keys** (components + the Zod-validated render depend on them).
+2. **`src/content/` MDX + JSON** — per-item content with YAML frontmatter:
+   - `projects/*.mdx` — portfolio items (body + frontmatter)
+   - `experience/*.mdx` — roles (body + frontmatter)
+   - `about/index.mdx` — bio + languages
+   - `companies/*.json` — "Worked with" strip (name/order only)
+
+The facts in the MDX were migrated from the original Sanity CMS (a one-time export, not kept
+in the repo) plus **LinkedIn** (`cz.linkedin.com/in/danielchomat`) and the old live site —
+the **migrated MDX is now the source of truth**. **Never invent facts** — pull from the
+existing content, Daniel's LinkedIn, or ask Daniel. (Old CMS data is re-exportable from
+Sanity if a fact needs re-checking.)
+
+---
+
+## 3. Content map — what you see on the page → where it comes from
+
+### Homepage (`/`)
+
+| On screen | Source |
+|---|---|
+| Browser tab title / meta description | `site.ts → meta.title`, `meta.description` |
+| OG share-card tagline | `site.ts → meta.ogTagline`, `meta.ogLocale` |
+| Nav labels | `site.ts → nav[]` (`label` desktop, `short` mobile pill) |
+| Hero name | `site.ts → hero.name` |
+| Hero mono identity line | `site.ts → hero.identityMono` |
+| Hero bio sentence | `site.ts → hero.bioBefore/bioMark/bioMid/bioMarkAlt/bioAfter` ⚠ see §4 |
+| Status card "Currently at …" | `hero.status.roleLead/roleBold/roleTrail` + `roleBody` |
+| Status card "Building …" | `hero.status.buildingLead/buildingBold/buildingTrail` + `buildingBody` |
+| Status card availability line | `hero.status.availability` |
+| Status card button | `hero.status.ctaPrimary` (`ctaSecondary` parked) |
+| "Now building" heading/eyebrow | `site.ts → now.kicker/count/headingMain/headingMuted` |
+| Now small-card eyebrows | `site.ts → now.cardKickers` (keyed by project slug) |
+| Now **featured** card body + tech | the **building** project with `bentoSize: xl` → its MDX body |
+| Now small cards (title/body/tech) | other **building** projects → their MDX |
+| Experience heading + intro | `site.ts → experience.headingMain/headingMuted/intro` |
+| Experience cards (homepage) | each `experience/*.mdx` **`summary`** only (body NOT shown here) |
+| "Worked with" label/range | `site.ts → companies.label/range` |
+| Company names/logos | `companies/*.json` (`name`; logo = auto initials) |
+| Work heading + footer note | `site.ts → work.headingMain/headingMuted/footerNote` |
+| Work cards | featured non-building `projects/*.mdx`: **`tagline`, `homeLabel`, `client`, `year`, `sticker`** (body NOT shown here) |
+| Tech section heading + group labels | `site.ts → tech.*` |
+| Tech pills (3 groups) | `site.ts → tech.techNow / techProduction / techCurious` |
+| "This site: Astro + MDX" footnote | `site.ts → tech.footnote` |
+| About card prose (in Tech section) | `about/index.mdx` body |
+| About language pills | `about/index.mdx` frontmatter `languages[].code` |
+| Contact heading + note | `site.ts → contact.headingMain/headingMuted/note` |
+| Contact cards (GitHub/LinkedIn) | `site.ts → contact.cards[]` (`kicker/handle/blurb/foot/href`) |
+| Footer | `site.ts → footer.*` |
+
+### Experience page (`/experience`)
+
+| On screen | Source |
+|---|---|
+| Page title/description | `src/pages/experience.astro` (hardcoded — edit there if needed) |
+| Header kicker/heading/intro | `site.ts → experiencePage.kicker/headingMain/intro` |
+| "About · short version" card | `site.ts → experiencePage.about.headingLead/headingMark/headingTrail` + `pills` |
+| Snapshot cards (4) | `site.ts → experiencePage.summary[]` (`kicker/title/blurb`) |
+| Timeline entries: header/meta | each `experience/*.mdx` frontmatter (`company/title/location/intervals/tech`) |
+| Timeline entries: summary line | `experience/*.mdx` **`summary`** |
+| Timeline entries: full prose | `experience/*.mdx` **body** (shown here, unlike homepage) |
+
+### 404 (`/404`)
+
+All copy in `site.ts → notFound.*` (heading, body, cards, footnote).
+
+---
+
+## 4. Render rules & constraints (so edits don't break layout)
+
+- **Hero bio is split across `<span>`s** (`bioBefore` → highlighted `bioMark` → `bioMid`
+  → highlighted `bioMarkAlt` → `bioAfter`). Write them so concatenated they read as **one
+  flowing sentence**; `bioMark`/`bioMarkAlt` are the two highlighted phrases.
+- **`summary` vs body:** experience `summary` shows on **both** homepage card and
+  `/experience`; the MDX **body** shows **only on `/experience`**. Don't repeat the
+  summary in the body.
+- **Work cards ignore the project body** — only `tagline`, `homeLabel`, `client`, `year`,
+  `sticker` are visible on the homepage. Put the punch there. (The body is for a future
+  `/projects` page.)
+- **Now requires exactly one `building` project with `bentoSize: xl`** (the featured
+  card) — currently `moments`. Don't remove it without promoting another.
+- **Bento grid = 12 columns.** Sizes: `sm=4, md=5, lg=7, xl=12`. Rows should sum to 12
+  (`7+5` or `4+4+4`); a partial last row is fine. The Work section is currently
+  `7+5 / 7+5 / 4+4` (6 cards).
+- **Length guides:** taglines 6–12 words; `homeLabel` ≤ ~5 words; status-card bodies
+  1–2 short sentences; experience/project bodies 2–4 sentences; About 2–3 sentences.
+- Use `&nbsp;` to keep tight pairs together (e.g. `React&nbsp;Native`) so they don't wrap.
+
+---
+
+## 5. Frontmatter schema (valid values — build fails otherwise)
+
+Canonical schema: `src/content.config.ts`.
+
+**projects/\*.mdx**
+```yaml
+title: string                 # required
+tagline: string               # required (short line)
+status: shipped|building|archived|private   # required
+kind: personal|client         # required
+client: string                # client work only
+tech: [string, ...]
+year: string                  # e.g. "2024", "21–23"
+bentoSize: sm|md|lg|xl         # default sm
+featured: boolean             # true = shows on homepage
+sticker: { tone: butter|sage|rose|sky|lavender|teal, text: string }
+homeLabel: string             # card line on homepage
+order: number                 # lower = first
+# body: 2–4 sentence MDX below the --- (Now cards only; Work cards hide it)
+```
+
+**experience/\*.mdx**
+```yaml
+company: string               # required
+title: string                 # required
+intervals:                    # required, ≥1; "present" = current role
+    - { start: YYYY-MM-DD, end: YYYY-MM-DD | present }
+location: string
+tech: [string, ...]
+nda: boolean
+summary: string               # required, one sentence (homepage + /experience)
+tint: butter|sage|rose|sky|lavender|mint|blossom|coral|peach|lime|teal|""   # teal = current role
+order: number                 # 0 = current, grows downward
+# body: 2–4 sentence MDX below the ---
+```
+
+**about/index.mdx** — `location: string`, `languages: [{ code: string }]` (order EN/ES/CZ).
+**companies/\*.json** — `{ "name": string, "order": number }`.
+
+---
+
+## 6. Voice examples (before → after)
+
+- "Built the first Czech app-only bank." → "I helped build the first Czech app-only
+  bank — then came back to ship the next version."
+- "Experimenting with small mobile apps…" → "Small mobile apps in evenings and weekends —
+  parenting, travel, and everyday utilities. Simple, focused, useful."
+- "Reads more than they should." → "I read more than I should."
+
+---
+
+## 7. Paste-ready prompt
+
+```
+You are editing copy for chomat.tech, Daniel Chomat's personal site. The CONTENT.md
+brief below is your only context — do not ask to read the codebase.
+
+Rules:
+- Voice: first person, broad personal brand, tight + warm (CONTENT.md §1).
+- Do NOT invent facts; use only what I give you or what's in the brief. Flag anything
+  you're unsure about instead of guessing.
+- Keep the settled decisions (no Canada, "six years" framing, EN/ES/CZ languages).
+- Change string VALUES only in site.ts — never keys. Keep frontmatter enums valid (§5).
+- Respect render constraints (§4): hero bio span-split, summary vs body, Work-card
+  visible fields, bento 12-col math, the xl-building-project requirement.
+
+Output: for each file, give the full new file contents OR exact find/replace blocks.
+
+--- CONTENT.md ---
+<paste this whole file>
+--- END ---
+
+What I want to change:
+<<< describe the change — e.g. "rewrite the hero bio to lead with mobile",
+    "update the status card: I just started at <Company>", "add a project: …" >>>
+```

--- a/src/content/about/index.mdx
+++ b/src/content/about/index.mdx
@@ -1,10 +1,11 @@
 ---
 location: Czechia
 languages:
-    - code: CZ
     - code: EN
     - code: ES
+    - code: CZ
 ---
 
-Based in **Czechia**. Speaks CZ / EN / partial ES (B1, working on
-it). Reads more than they should. Builds with their family in mind.
+Based in **Czechia**. I build iOS and Android apps with React Native, and
+I've been shipping for the web and mobile since 2017. I read more than I
+should, and I build with my family in mind.

--- a/src/content/companies/niteowl.json
+++ b/src/content/companies/niteowl.json
@@ -1,0 +1,4 @@
+{
+    "name": "NiteOwl",
+    "order": 6
+}

--- a/src/content/experience/freelance.mdx
+++ b/src/content/experience/freelance.mdx
@@ -9,15 +9,17 @@ tech:
     - React Native
     - Expo
     - Next.js
+    - React
     - TypeScript
     - Turborepo
 nda: false
-summary: "GlobalLogic · Purple Next · misc client work."
+summary: "Two years of client work — GlobalLogic, Purple Next, NiteOwl, and smaller pieces."
 tint: ""
 order: 1
 ---
 
-A two-year umbrella covering a string of client engagements:
-greenfield React&nbsp;Native work for a US medical startup via
-GlobalLogic, an FX banking rewrite at Purple Next, and a handful
-of smaller pieces in between.
+Two years under my own shingle, across a string of client engagements:
+greenfield React&nbsp;Native for a US medical startup via GlobalLogic,
+an FX banking rewrite at Purple Next, and a React&nbsp;Native rewrite
+of a nightlife app for NiteOwl. In between, smaller pieces — including
+some coding help for TalentPilot when they needed an extra pair of hands.

--- a/src/content/experience/partners-bank.mdx
+++ b/src/content/experience/partners-bank.mdx
@@ -16,13 +16,15 @@ tech:
     - Parcel
     - WebView
 nda: true
-summary: "Built the first Czech app-only retail bank. Came back to ship v2."
+summary: "I helped build the first Czech app-only bank — then came back to ship the next version."
 tint: teal
 order: 0
 ---
 
-Joined the front-end team at the start of a brand-new app-only bank
-in the Czech Republic, working iOS and Android from day one. Shipped
-the launch (App Store Connect, TestFlight, Google Play), mentored
-juniors, and partnered daily with backend, QA, and product. Came
-back in 2025 to help with the next version.
+I joined the front-end team at the very start of a brand-new, app-only
+bank in the Czech Republic — iOS and Android from day one. From the
+first line of code to launch, I helped get it into the App Store and
+Google Play, fixed production issues, and became a go-to for our junior
+developers. Working day to day with backend, QA, and product is where
+React&nbsp;Native really clicked for me. I came back in 2025 to help
+build the next version.

--- a/src/content/experience/refresh.mdx
+++ b/src/content/experience/refresh.mdx
@@ -19,14 +19,14 @@ tech:
     - Styled Components
     - Docker
 nda: false
-summary: "Prague digital agency. Web → mobile transition."
+summary: "Two years at a Prague digital agency — where web turned into mobile for me."
 tint: ""
 order: 2
 ---
 
-Two years at a Prague digital agency, building presentation
-websites and e-shops on Gatsby + headless CMS, helping ship a
-React/Storybook design system, and contributing to one of the
-first fully-online contract renegotiation flows in the country.
-Transitioned full-time into mobile near the end. Clients
-included MND, Kapitol, EY, NanoComposix.
+Two years at a Prague digital agency, building presentation sites and
+e-shops on Gatsby and headless CMS, helping ship a React&nbsp;+&nbsp;Storybook
+design system, and contributing to one of the country's first fully-online
+contract-renegotiation flows. I moved full-time into mobile near the end —
+the start of a brand-new Czech bank. Clients included MND, Kapitol, EY,
+and NanoComposix.

--- a/src/content/projects/niteowl.mdx
+++ b/src/content/projects/niteowl.mdx
@@ -1,0 +1,22 @@
+---
+title: NiteOwl
+tagline: Nightlife social app
+status: shipped
+kind: client
+client: NiteOwl
+year: "2025"
+tech: [React Native, Expo, TypeScript]
+bentoSize: lg
+featured: true
+startDate: 2025-01-01
+endDate: 2025-05-31
+sticker:
+    tone: teal
+    text: "rewrite"
+homeLabel: "Stabilised the core, reworked the UX"
+order: 2
+---
+
+A React&nbsp;Native rewrite of an app that connects people around nightlife.
+I refactored the core features for stability, reworked the UX alongside
+product and design, and tightened the tooling and deployment along the way.

--- a/src/content/projects/nostalgic.mdx
+++ b/src/content/projects/nostalgic.mdx
@@ -1,0 +1,23 @@
+---
+title: Nostalgic Trains
+tagline: Train seat reservation
+status: archived
+kind: client
+client: Freelance
+year: "2019"
+tech: [Vanilla JS, CSS Grid, SCSS, WordPress]
+bentoSize: sm
+featured: true
+startDate: 2019-06-01
+endDate: 2019-09-30
+sticker:
+    tone: butter
+    text: "in cold storage"
+homeLabel: "Built. Then forgot to launch."
+order: 4
+---
+
+A freelance gig: a seat-selection interface for vintage train carriages,
+built in vanilla JS and CSS Grid and wired into a custom WordPress plugin.
+The pandemic killed the launch window — it never went live, but the code
+is still there.

--- a/src/content/projects/pbk.mdx
+++ b/src/content/projects/pbk.mdx
@@ -1,0 +1,23 @@
+---
+title: PBK Mobile
+tagline: Czech retail bank · NDA
+status: shipped
+kind: client
+client: Partners Bank
+year: "21–23"
+tech: [React Native, Expo, react-hook-form, react-query, TypeScript, Parcel, WebView]
+bentoSize: md
+featured: true
+startDate: 2021-09-01
+endDate: 2023-08-31
+sticker:
+    tone: sage
+    text: "live · 2yr+"
+homeLabel: "Still in the App Store"
+order: 3
+---
+
+The first Czech app-only retail bank. I worked iOS and Android from
+day one — first line of code to release across App Store Connect,
+TestFlight, and Google Play — mentored juniors, and collaborated
+daily with backend, QA, and product.

--- a/src/content/projects/socialsharks.mdx
+++ b/src/content/projects/socialsharks.mdx
@@ -1,0 +1,22 @@
+---
+title: SocialSharks
+tagline: Landing pages cluster
+status: shipped
+kind: client
+client: Freelance
+year: "2019"
+tech: [SCSS, PHP, Vanilla JS]
+bentoSize: sm
+featured: true
+startDate: 2019-04-01
+endDate: 2019-09-30
+sticker:
+    tone: lavender
+    text: "freelance · 5×"
+homeLabel: "Cluster of landing pages"
+order: 5
+---
+
+Through my own contacts, a run of design-heavy landing pages for media
+agency SocialSharks and their roster — Freedom Music, Marilla, Lloyd
+among others. Tight deadlines, intricate art direction, hand-coded SCSS.

--- a/src/content/projects/usmed.mdx
+++ b/src/content/projects/usmed.mdx
@@ -1,0 +1,24 @@
+---
+title: US Med Startup
+tagline: Health-measuring app · NDA
+status: private
+kind: client
+client: GlobalLogic
+year: "2024"
+tech: [React Native, Expo, EAS, orval, Zustand, victory-native, Skia, Biometry]
+bentoSize: md
+featured: true
+startDate: 2024-02-01
+endDate: 2024-07-31
+sticker:
+    tone: rose
+    text: "NDA"
+homeLabel: "Shipped — then NDA-shrouded"
+order: 1
+---
+
+Via GlobalLogic, I joined a small team building the companion app for
+a US medical startup’s measuring device. I worked directly with the
+client through frequent demos, shaped architecture and deployment from
+the ground up, and shipped a greenfield React&nbsp;Native + Expo product
+end to end.

--- a/src/content/projects/walletory.mdx
+++ b/src/content/projects/walletory.mdx
@@ -1,0 +1,24 @@
+---
+title: Walletory
+tagline: FX banking platform
+status: shipped
+kind: client
+client: Purple Next
+year: "2023"
+tech: [Next.js, Turborepo, Biome, TypeScript]
+bentoSize: lg
+featured: true
+startDate: 2023-08-01
+endDate: 2023-11-30
+sticker:
+    tone: sky
+    text: "pre-launch"
+homeLabel: "Helped get to the finish line"
+order: 0
+---
+
+I joined a complete rewrite of an unreleased web app for an
+international e-banking / FX platform. I shaped the architecture and
+deployment process with the lead developer, and consulted the
+newly-formed design team on UX/UI. Budget cuts across the FX industry
+shut the project down shortly after.

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -6,7 +6,7 @@ export const SITE = {
     meta: {
         title: "Daniel Chomat — Senior React Native Engineer",
         description:
-            "React Native engineer focused on production mobile apps, product thinking, and modern front-end architecture. Experience across fintech, healthcare, and startup products.",
+            "I'm a React Native engineer focused on production mobile apps, product thinking, and modern front-end architecture — with six years across fintech, healthcare, and startups.",
         siglum: "chomat.tech · v2",
         // Open Graph card copy (rendered by src/pages/og.png.ts). Kept here
         // so the share image stays a render-only consumer of site content.
@@ -25,9 +25,9 @@ export const SITE = {
         kicker: "chomat.tech · v2",
         name: "Daniel Chomat",
         identityMono: "* Senior React Native engineer · Czechia ",
-        bioBefore: "Six years building production-ready applications across ",
+        bioBefore: "I've spent six years building production apps across ",
         bioMark: "fintech, healthcare, and digital products",
-        bioMid: ". Started in front-end development before moving deeper into ",
+        bioMid: ". I started in front-end, then went deeper into ",
         bioMarkAlt: "React Native and mobile product engineering",
         bioAfter: ".",
         status: {
@@ -37,13 +37,13 @@ export const SITE = {
             roleBold: "Partners Bank",
             roleTrail: ".",
             roleBody:
-                "Helping build a Czech mobile-only bank, with focus on React Native, product quality, and reliable delivery.",
+                "Back helping build a Czech mobile-only bank — React Native, product quality, and reliable delivery.",
             buildingLead: "Building ",
             buildingBold: "side products",
             buildingTrail: ".",
             buildingBody:
-                "Experimenting with small mobile apps around parenting, travel, and everyday utility tools — simple, focused, and useful.",
-            availability: "Open to selected freelance opportunities and good async conversations.",
+                "Small mobile apps in evenings and weekends — parenting, travel, and everyday utilities. Simple, focused, useful.",
+            availability: "Open to selected freelance and good async conversations.",
             ctaPrimary: "See what I’m building",
             ctaPrimaryHref: "#now",
             ctaSecondary: "Resume.pdf",
@@ -74,7 +74,7 @@ export const SITE = {
         link: { label: "full timeline", href: "/experience" },
         headingMain: "Six years, ",
         headingMuted: "from web to mobile.",
-        intro: "Started with front-end and agency work, moved into React Native, and took on broader ownership across architecture, delivery, deployment, and product implementation.",
+        intro: "I started in front-end and agency work, moved into React Native, and took on broader ownership across architecture, delivery, deployment, and product.",
         currentLabel: "Currently here",
     },
     companies: {
@@ -178,11 +178,11 @@ export const SITE = {
         kicker: "§ Experience · the long version",
         headingMain: "Six years.",
         headingMark: "*",
-        intro: "Front-end first, React Native next. Agency work, fintech, healthcare, and client projects — with ownership across requirements, architecture, delivery, and deployment.",
+        intro: "Front-end first, React Native next. Agency work, fintech, healthcare, and client projects — owning requirements, architecture, delivery, and deployment.",
         introMarkLead: "*",
         about: {
             kicker: "§ About · short version",
-            headingLead: "Product-minded engineer — ",
+            headingLead: "I'm a product-minded engineer — ",
             headingMark: "building mobile apps with real users and real constraints",
             headingTrail:
                 ". Based in Czechia, working across React Native, TypeScript, and modern front-end.",


### PR DESCRIPTION
## Summary
Editorial pass over all site copy for a **broad personal-brand** voice, sourced from the Sanity export and LinkedIn (no invented facts). No structural/CSS changes — content only.

- **First person throughout** — hero, status card, about, experience, project copy. Fixes the about bio's `they/their` vs `he/him` inconsistency.
- **Factual corrections** — Nostalgic Trains and SocialSharks were **2019 freelance** work, not Refresh client projects (`kind`/`client`/`year` fixed).
- **NiteOwl added** — 2025 nightlife-app rewrite as a featured project + in the "Worked with" strip; NiteOwl and (lightly) TalentPilot named in the freelance entry.
- **Languages** shown as `EN / ES / CZ` (dropping the understated "B1, working on it").
- Kept the **"six years (2019→)"** framing; **no Canada/relocation** messaging.

## Files
`src/data/site.ts`, `src/content/about/index.mdx`, 3 × `experience/*.mdx`, 6 × `projects/*.mdx` + new `projects/niteowl.mdx`, new `companies/niteowl.json`.

## Test plan
- [x] `npm run build` passes (Zod frontmatter validation, og.png regenerated, no dropped `SITE` keys)
- [x] Browser review of `/` (hero, Now, Work grid `7+5 / 7+5 / 4+4`, Companies = 7, Tech/About pills, Contact) and `/experience` (timeline, NiteOwl + TalentPilot mentions)
- [ ] Copy/tone read-through by Daniel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced six new portfolio projects: NiteOwl, Nostalgic Trains, PBK Mobile, SocialSharks, US Med, and Walletory.

* **Documentation**
  * Added comprehensive content editing documentation and guidelines.
  * Updated personal bio and experience descriptions.
  * Refreshed site-wide messaging and copy for improved clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DanielChomat/chomat.tech/pull/84?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->