### PR TITLE
polish: typographic quotes, NBSP brand terms, tabular-nums years

### DIFF
--- a/src/content/about/index.mdx
+++ b/src/content/about/index.mdx
@@ -6,6 +6,6 @@ languages:
     - code: CZ
 ---
 
-Based in **Czechia**. I build iOS and Android apps with React Native, and
-I've been shipping for the web and mobile since 2017. I read more than I
+Based in **Czechia**. I build iOS and Android apps with React&nbsp;Native, and
+I’ve been shipping for the web and mobile since 2017. I read more than I
 should, and I build with my family in mind.

--- a/src/content/experience/freelance.mdx
+++ b/src/content/experience/freelance.mdx
@@ -20,6 +20,6 @@ order: 1
 
 Two years under my own shingle, across a string of client engagements:
 greenfield React&nbsp;Native for a US medical startup via GlobalLogic,
-an FX banking rewrite at Purple Next, and a React&nbsp;Native rewrite
+an FX banking rewrite at Purple&nbsp;Next, and a React&nbsp;Native rewrite
 of a nightlife app for NiteOwl. In between, smaller pieces — including
 some coding help for TalentPilot when they needed an extra pair of hands.

--- a/src/content/experience/refresh.mdx
+++ b/src/content/experience/refresh.mdx
@@ -26,7 +26,7 @@ order: 2
 
 Two years at a Prague digital agency, building presentation sites and
 e-shops on Gatsby and headless CMS, helping ship a React&nbsp;+&nbsp;Storybook
-design system, and contributing to one of the country's first fully-online
+design system, and contributing to one of the country’s first fully-online
 contract-renegotiation flows. I moved full-time into mobile near the end —
 the start of a brand-new Czech bank. Clients included MND, Kapitol, EY,
 and NanoComposix.

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -6,12 +6,12 @@ export const SITE = {
     meta: {
         title: "Daniel Chomat — Senior React Native Engineer",
         description:
-            "I'm a React Native engineer focused on production mobile apps, product thinking, and modern front-end architecture — with six years across fintech, healthcare, and startups.",
+            "I’m a React Native engineer focused on production mobile apps, product thinking, and modern front-end architecture — with six years across fintech, healthcare, and startups.",
         siglum: "chomat.tech · v2",
         // Open Graph card copy (rendered by src/pages/og.png.ts). Kept here
         // so the share image stays a render-only consumer of site content.
         ogTagline:
-            "Senior React Native engineer. Six years across fintech, healthcare, and startups.",
+            "Senior React Native engineer. Six years across fintech, healthcare, and startups.",
         ogLocale: "Czechia · he/him",
     },
     nav: [
@@ -24,20 +24,20 @@ export const SITE = {
     hero: {
         kicker: "chomat.tech · v2",
         name: "Daniel Chomat",
-        identityMono: "* Senior React Native engineer · Czechia ",
-        bioBefore: "I've spent six years building production apps across ",
+        identityMono: "* Senior React Native engineer · Czechia ",
+        bioBefore: "I’ve spent six years building production apps across ",
         bioMark: "fintech, healthcare, and digital products",
         bioMid: ". I started in front-end, then went deeper into ",
-        bioMarkAlt: "React Native and mobile product engineering",
+        bioMarkAlt: "React Native and mobile product engineering",
         bioAfter: ".",
         status: {
-            ariaLabel: "What I'm working on now",
+            ariaLabel: "What I’m working on now",
             kicker: "/now · May 2026",
             roleLead: "Currently at ",
-            roleBold: "Partners Bank",
+            roleBold: "Partners Bank",
             roleTrail: ".",
             roleBody:
-                "Back helping build a Czech mobile-only bank — React Native, product quality, and reliable delivery.",
+                "Back helping build a Czech mobile-only bank — React Native, product quality, and reliable delivery.",
             buildingLead: "Building ",
             buildingBold: "side products",
             buildingTrail: ".",
@@ -65,7 +65,7 @@ export const SITE = {
         empty: {
             kicker: "Workshop",
             title: "Quiet on the bench right now.",
-            body: "I'm between builds — new experiments will show up here as they take shape.",
+            body: "I’m between builds — new experiments will show up here as they take shape.",
         },
     },
     experience: {
@@ -74,11 +74,11 @@ export const SITE = {
         link: { label: "full timeline", href: "/experience" },
         headingMain: "Six years, ",
         headingMuted: "from web to mobile.",
-        intro: "I started in front-end and agency work, moved into React Native, and took on broader ownership across architecture, delivery, deployment, and product.",
+        intro: "I started in front-end and agency work, moved into React Native, and took on broader ownership across architecture, delivery, deployment, and product.",
         currentLabel: "Currently here",
     },
     companies: {
-        ariaLabel: "Companies I've worked with",
+        ariaLabel: "Companies I’ve worked with",
         label: "Worked with",
         range: "2019 → now",
         countLabel: "companies",
@@ -178,14 +178,14 @@ export const SITE = {
         kicker: "§ Experience · the long version",
         headingMain: "Six years.",
         headingMark: "*",
-        intro: "Front-end first, React Native next. Agency work, fintech, healthcare, and client projects — owning requirements, architecture, delivery, and deployment.",
+        intro: "Front-end first, React Native next. Agency work, fintech, healthcare, and client projects — owning requirements, architecture, delivery, and deployment.",
         introMarkLead: "*",
         about: {
             kicker: "§ About · short version",
-            headingLead: "I'm a product-minded engineer — ",
+            headingLead: "I’m a product-minded engineer — ",
             headingMark: "building mobile apps with real users and real constraints",
             headingTrail:
-                ". Based in Czechia, working across React Native, TypeScript, and modern front-end.",
+                ". Based in Czechia, working across React Native, TypeScript, and modern front-end.",
             pills: ["React Native", "TypeScript", "mobile", "product"],
         },
         summary: [

--- a/src/styles/type.css
+++ b/src/styles/type.css
@@ -42,6 +42,10 @@
             letter-spacing: 0;
             text-transform: uppercase;
             color: var(--muted);
+            /* Year ranges, interval counters, and the Companies strip date/count
+               all render through .t-mono — keep their digits fixed-width so the
+               columns don't jiggle as glyphs change. */
+            font-variant-numeric: tabular-nums;
         }
         & .kicker {
             font-family: var(--font-mono);


### PR DESCRIPTION
Typography polish sweep. Closes #90, #91, #92.

## #90 — curly quotes + ellipsis
- Straight apostrophes → curly `'` (U+2019) in `site.ts` copy and MDX bodies (`I'm`, `I've`, `country's`).
- Code comments left as ASCII (not copy).
- No `...` triple-dots existed, so no ellipsis changes.

## #91 — non-breaking spaces in compound brand terms
- `React Native` / `Partners Bank` kept on one line. Literal **U+00A0** in `site.ts` strings — `&nbsp;` would be HTML-escaped when interpolated as a text node.
- `&nbsp;` entity in MDX bodies (`Purple Next`, `React Native`), matching the convention `freelance.mdx` already used.
- Skipped tech-pill arrays and discrete card titles — they don't wrap mid-name.

## #92 — text-wrap balance + tabular-nums
- `text-wrap: balance` was **already** on `.t-mega` and `.t-heading` — no change needed.
- Added `font-variant-numeric: tabular-nums` to `.t-mono`, the single tag every year range / interval / counter renders through (Companies strip, experience intervals, jump-nav years, project years).

## Verification
- `yarn check:astro` — 0 errors / 0 warnings / 0 hints
- `yarn build` — clean (3 pages)
- `npx biome check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced typography with improved apostrophe styling throughout site content for a more polished, professional appearance.
  * Improved text spacing by applying non-breaking spaces to key phrases, ensuring better layout consistency and readability.
  * Refined monospace numerals to display with fixed, consistent spacing, preventing visual misalignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->